### PR TITLE
Fix for 'Not Responding' when using SSH on some systems

### DIFF
--- a/com/repdev/DirectSymitarSession.java
+++ b/com/repdev/DirectSymitarSession.java
@@ -155,7 +155,7 @@ public class DirectSymitarSession extends SymitarSession {
 	    }
 		try {
 			if(useSSH){
-				String command = "plink -load aixterm " + server;
+				String command = "plink -load aixterm " + aixUsername + "@" + server;
 				p = Runtime.getRuntime().exec(command);
 				
 				in = new BufferedReader(new InputStreamReader(p.getInputStream()));


### PR DESCRIPTION
Please review this fix for using SSH connections where RepDev will lock up with a Not Responding message on some systems when trying to connect to a SYM institution.