### PR TITLE
Save source control version before remote version

### DIFF
--- a/com/repdev/SymitarFile.java
+++ b/com/repdev/SymitarFile.java
@@ -139,15 +139,16 @@ public class SymitarFile implements Serializable {
 			SessionError error;
 		
 			try{
-				error = RepDevMain.SYMITAR_SESSIONS.get(sym).saveFile(this, data);
-				
-				if( error != SessionError.NONE)
-					error.showError();
 				if(this.syncRepGen()) {
 					SourceControl sc=new SourceControl();
 					SymitarFile sourceControl = sc.getSourceControlFile(this);
 					sourceControl.saveFile(data);
 				}
+
+				error = RepDevMain.SYMITAR_SESSIONS.get(sym).saveFile(this, data);
+				
+				if( error != SessionError.NONE)
+					error.showError();
 			}
 			catch(Exception e){
 				error = SessionError.NULL_POINTER;


### PR DESCRIPTION
If anything goes wrong with remote saving, RepDev freezes and must be terminated.  This ensures a local copy of your changes get saved first so you don't lose your work.