### PR TITLE
(feat) Make the code-folding gutter configurable via styles and options

### DIFF
--- a/com/repdev/Config.java
+++ b/com/repdev/Config.java
@@ -73,7 +73,12 @@ public class Config implements Serializable {
 	private boolean fileNameInWinTitle = true;
 	private boolean hostInTitle = true;
 	private boolean viewLineNumbers = true;
-	
+	// Stored inverted on purpose: existing repdev.conf files were serialized before this
+	// field existed, so on load Java sets it to the boolean default (false). Keeping the
+	// "disabled" sense means that default maps to folding ENABLED, matching the intended
+	// default for upgraders. Always go through get/setFoldingEnabled below.
+	private boolean foldingDisabled = false;
+
 	@SuppressWarnings("unused")
 	private int maxQueues = 3; //The largest value this slider goes up to, We should probably scrap this since the max value is 9999 and the error checking code is good enough now that it can detect what needs to be entered. In real life, this can also be non continous large ranges, which complicates things.
 							//UPDATE: Ok, this has been removed, however, you can't remove items from Serialized classes.
@@ -549,5 +554,13 @@ public class Config implements Serializable {
 
 	public static boolean getViewLineNumbers(){
 		return me.viewLineNumbers;
+	}
+
+	public static void setFoldingEnabled(boolean enabled){
+		me.foldingDisabled = !enabled;
+	}
+
+	public static boolean getFoldingEnabled(){
+		return !me.foldingDisabled;
 	}
 }

--- a/com/repdev/EditorComposite.java
+++ b/com/repdev/EditorComposite.java
@@ -582,6 +582,30 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 	public FoldingManager getFolding(){
 		return folding;
 	}
+
+	/**
+	 * Live-disable code folding for this editor: unfold everything, then drop the fold
+	 * manager, its gutter column, and its listeners so the buffer reverts to plain-editor
+	 * behavior (no fold icons, hotkeys, or unfold-on-save). Called when the user turns off
+	 * "Enable code folding" and saves, so open tabs update without a reopen.
+	 *
+	 * Re-enabling only takes effect when an editor is (re)opened — the fold listener must
+	 * be registered ahead of the highlighter's for correct parser ordering (see the
+	 * construction comment above), which a live re-attach can't guarantee.
+	 */
+	public void disableFolding(){
+		if (folding == null) return;
+		if (folding.hasActiveFolds()) folding.expandAllSilent();
+		if (parser != null) parser.setHiddenTextProvider(null);
+		folding.dispose();
+		folding = null;
+		if (!txt.isDisposed()) {
+			// Shrink the gutter back (calcWidth now excludes the fold column) and repaint.
+			txt.setMargins(calcWidth(), 0, 0, 0);
+			txt.redraw();
+		}
+	}
+
 	private void buildGUI() {
 		setLayout(new FormLayout());
 
@@ -614,7 +638,7 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 		// is only correct once fold headerLines reflect the post-edit line
 		// numbering. Reversing this order causes parser state to drift one edit
 		// behind the buffer when folds are active.
-		if (file.getType() == FileType.REPGEN) {
+		if (file.getType() == FileType.REPGEN && Config.getFoldingEnabled()) {
 			folding = new FoldingManager(this, txt, parser);
 			parser.setHiddenTextProvider(folding);
 		}

--- a/com/repdev/FoldingManager.java
+++ b/com/repdev/FoldingManager.java
@@ -19,6 +19,7 @@
 
 package com.repdev;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -101,7 +102,18 @@ public class FoldingManager implements HiddenTextProvider {
 	private final ArrayList<FoldRegion> folded = new ArrayList<FoldRegion>();
 	private final ArrayList<FoldableRange> foldable = new ArrayList<FoldableRange>();
 
-	private final Color markerColor;
+	/** Fallback triangle color when the active style declares no <folding fgColor="..."/>. */
+	private static final RGB DEFAULT_MARKER_RGB = new RGB(90, 90, 90);
+	/** Marker glyph styles selectable via the style's {@code <folding shape="..."/>} attribute. */
+	private static final String SHAPE_TRIANGLE = "triangle";
+	private static final String SHAPE_PLUSMINUS = "plusminus";
+	// Not final: refreshStyle() disposes and recreates these when the theme changes.
+	private Color markerColor;
+	// Always-on vertical guide line drawn from each expanded block's icon down to its end.
+	private Color guideColor;
+	// Which glyph to paint in the fold gutter. Defaults to triangles; a style may opt
+	// into boxed +/- markers with shape="plusminus".
+	private String markerShape = SHAPE_TRIANGLE;
 	private boolean inFoldOp = false;
 	// True while a fold-all is iterating. Individual collapse/expand ops suppress
 	// their per-op parser.reparseAll() + recomputeRanges() (which triggers the
@@ -119,9 +131,74 @@ public class FoldingManager implements HiddenTextProvider {
 		this.editor = editor;
 		this.txt = txt;
 		this.parser = parser;
-		this.markerColor = new Color(txt.getDisplay(), new RGB(90, 90, 90));
+		loadFoldingStyle();
 		install();
 	}
+
+	/**
+	 * Read the fold marker's color, glyph shape, and guide-line color from the active
+	 * style's {@code <folding fgColor="..." shape="..." guideColor="..."/>} element in one
+	 * parse, and (re)build {@link #markerColor} / {@link #markerShape} / {@link #guideColor}.
+	 * Missing or malformed values fall back to {@link #DEFAULT_MARKER_RGB},
+	 * {@link #SHAPE_TRIANGLE}, and — for the guide — a dimmed blend of the marker color
+	 * toward the editor background, so older or custom style files keep working. Mirrors
+	 * how SyntaxHighlighter resolves per-element style values.
+	 */
+	private void loadFoldingStyle() {
+		RGB rgb = DEFAULT_MARKER_RGB;
+		RGB guideRgb = null;
+		RGB bg = null;
+		String shape = SHAPE_TRIANGLE;
+		try {
+			Style style = new Style(new File("styles\\" + Config.getStyle() + ".xml"));
+			RGB c = style.getColor("folding", "fgColor");
+			if (c != null) rgb = c;
+			String s = style.getValue("folding", "shape");
+			if (s != null && s.trim().length() > 0) shape = s.trim().toLowerCase();
+			guideRgb = style.getColor("folding", "guideColor"); // explicit override; may be null
+			bg = style.getColor("editor", "bgColor");           // used to dim the default guide
+		} catch (Exception ex) {
+			// Malformed/absent style file — keep the default gray triangle.
+		}
+		if (guideRgb == null) guideRgb = dimToward(rgb, bg);
+
+		Color oldMarker = markerColor;
+		Color oldGuide = guideColor;
+		markerColor = new Color(txt.getDisplay(), rgb);
+		guideColor = new Color(txt.getDisplay(), guideRgb);
+		if (oldMarker != null && !oldMarker.isDisposed()) oldMarker.dispose();
+		if (oldGuide != null && !oldGuide.isDisposed()) oldGuide.dispose();
+		markerShape = shape;
+	}
+
+	/**
+	 * Default fold-guide color: the marker color blended halfway toward the editor
+	 * background so the always-on guide line reads as a dimmed version of the icon.
+	 * Falls back to a mid-gray blend when the background is unknown (e.g. randomized styles).
+	 */
+	private static RGB dimToward(RGB c, RGB bg) {
+		RGB target = (bg != null) ? bg : new RGB(128, 128, 128);
+		return new RGB((c.red + target.red) / 2,
+		               (c.green + target.green) / 2,
+		               (c.blue + target.blue) / 2);
+	}
+
+	/**
+	 * Re-read the fold marker's color and shape from the current style and repaint. Called
+	 * after a theme change so open editors update live, matching how syntax colors refresh.
+	 */
+	public void refreshStyle() {
+		if (txt.isDisposed()) return;
+		loadFoldingStyle();
+		txt.redraw();
+	}
+
+	// Listener references retained so dispose() can unregister them — required when
+	// folding is torn down live (user disables the feature) rather than only at editor
+	// close, so a detached manager stops receiving edit/paint/click events.
+	private ExtendedModifyListener modifyListener;
+	private PaintListener paintListener;
+	private MouseAdapter mouseListener;
 
 	private void install() {
 		// Registered first so headerLine shifts complete before downstream
@@ -129,19 +206,21 @@ public class FoldingManager implements HiddenTextProvider {
 		// Without this ordering, parser-side canonical-source reassembly sees
 		// stale headerLine values for one edit cycle and reinserts hidden
 		// blocks at the wrong offset — corrupting model-coord parse state.
-		txt.addExtendedModifyListener(new ExtendedModifyListener() {
+		modifyListener = new ExtendedModifyListener() {
 			public void modifyText(ExtendedModifyEvent event) {
 				onTextModified(event);
 			}
-		});
+		};
+		txt.addExtendedModifyListener(modifyListener);
 
-		txt.addPaintListener(new PaintListener() {
+		paintListener = new PaintListener() {
 			public void paintControl(PaintEvent e) {
 				paintMarkers(e);
 			}
-		});
+		};
+		txt.addPaintListener(paintListener);
 
-		txt.addMouseListener(new MouseAdapter() {
+		mouseListener = new MouseAdapter() {
 			public void mouseDown(MouseEvent e) {
 				if (e.button != 1 || txt.getLineHeight() == 0) return;
 				int gutter = editor.calcWidth();
@@ -152,7 +231,8 @@ public class FoldingManager implements HiddenTextProvider {
 				if (line < 0 || line >= txt.getLineCount()) return;
 				toggleAtLine(line);
 			}
-		});
+		};
+		txt.addMouseListener(mouseListener);
 	}
 
 	/**
@@ -951,6 +1031,35 @@ public class FoldingManager implements HiddenTextProvider {
 		GC gc = e.gc;
 		Color oldFg = gc.getForeground();
 		Color oldBg = gc.getBackground();
+
+		// Always-on fold guide lines: a dimmed vertical line from each expanded block's
+		// icon down to its end line, capped with a short foot (└). Drawn before the glyphs
+		// so the icons sit on top. Iterates the foldable list directly — not just the
+		// visible rows — so the guide still shows when its header has scrolled off the top;
+		// the span is clipped to the client area in pixel space.
+		gc.setForeground(guideColor);
+		int lastLine = txt.getLineCount() - 1;
+		for (int i = 0; i < foldable.size(); i++) {
+			FoldableRange fr = foldable.get(i);
+			int endLine = fr.endLine;
+			if (endLine > lastLine) endLine = lastLine;
+			if (endLine <= fr.headerLine) continue;
+			int yHead, yEnd;
+			try {
+				yHead = txt.getLocationAtOffset(txt.getOffsetAtLine(fr.headerLine)).y;
+				yEnd = txt.getLocationAtOffset(txt.getOffsetAtLine(endLine)).y;
+			} catch (IllegalArgumentException ex) { continue; }
+			int yStart = yHead + (lh / 2) + 7; // just below the header glyph
+			int yStop = yEnd + (lh / 2);       // middle of the end row
+			if (yStop <= yStart) continue;
+			boolean endVisible = (yStop >= 0 && yStop <= clientH);
+			int a = Math.max(yStart, 0);
+			int b = Math.min(yStop, clientH);
+			if (b <= a) continue;
+			gc.drawLine(cx, a, cx, b);
+			if (endVisible) gc.drawLine(cx, b, cx + 4, b); // foot marking the block end
+		}
+
 		gc.setForeground(markerColor);
 		gc.setBackground(markerColor);
 
@@ -963,15 +1072,29 @@ public class FoldingManager implements HiddenTextProvider {
 				y = txt.getLocationAtOffset(txt.getOffsetAtLine(line)).y;
 			} catch (IllegalArgumentException ex) { continue; }
 			int cy = y + (lh / 2);
-			int s = 6;
-			if (isFolded) {
-				// Right-pointing triangle (region is collapsed)
-				int[] pts = { cx - (s - 2), cy - s, cx + (s - 1), cy, cx - (s - 2), cy + s };
-				gc.fillPolygon(pts);
+			if (SHAPE_PLUSMINUS.equals(markerShape)) {
+				// Boxed +/- : a bordered square with a horizontal bar (expanded, "-"),
+				// plus a vertical bar when collapsed to form "+". Only the outline and
+				// bars are stroked in markerColor; the box interior stays the editor
+				// background (drawRectangle/drawLine use the foreground only).
+				int half = 5;   // box half-size → 10px square
+				int inset = 2;  // bar padding inside the box
+				gc.drawRectangle(cx - half, cy - half, half * 2, half * 2);
+				gc.drawLine(cx - half + inset, cy, cx + half - inset, cy);
+				if (isFolded)
+					gc.drawLine(cx, cy - half + inset, cx, cy + half - inset);
 			} else {
-				// Down-pointing triangle (region is expanded, click to collapse)
-				int[] pts = { cx - s, cy - (s - 3), cx + s, cy - (s - 3), cx, cy + (s - 1) };
-				gc.fillPolygon(pts);
+				// Triangles (default shape).
+				int s = 6;
+				if (isFolded) {
+					// Right-pointing triangle (region is collapsed)
+					int[] pts = { cx - (s - 2), cy - s, cx + (s - 1), cy, cx - (s - 2), cy + s };
+					gc.fillPolygon(pts);
+				} else {
+					// Down-pointing triangle (region is expanded, click to collapse)
+					int[] pts = { cx - s, cy - (s - 3), cx + s, cy - (s - 3), cx, cy + (s - 1) };
+					gc.fillPolygon(pts);
+				}
 			}
 		}
 		gc.setForeground(oldFg);
@@ -979,6 +1102,12 @@ public class FoldingManager implements HiddenTextProvider {
 	}
 
 	public void dispose() {
+		if (!txt.isDisposed()) {
+			if (modifyListener != null) txt.removeExtendedModifyListener(modifyListener);
+			if (paintListener != null) txt.removePaintListener(paintListener);
+			if (mouseListener != null) txt.removeMouseListener(mouseListener);
+		}
 		if (markerColor != null && !markerColor.isDisposed()) markerColor.dispose();
+		if (guideColor != null && !guideColor.isDisposed()) guideColor.dispose();
 	}
 }

--- a/com/repdev/MainShell.java
+++ b/com/repdev/MainShell.java
@@ -4027,6 +4027,37 @@ public class MainShell {
 		return mainfolder;
 	}
 
+	/**
+	 * Tear down code folding on every open editor. Called when the user disables the
+	 * "Enable code folding" option so open tabs unfold and lose their fold gutter
+	 * immediately, rather than staying folded until reopened.
+	 */
+	public void disableFoldingOnOpenEditors() {
+		if (mainfolder == null || mainfolder.isDisposed())
+			return;
+		for (CTabItem tab : mainfolder.getItems()) {
+			if (tab.getControl() instanceof EditorComposite)
+				((EditorComposite) tab.getControl()).disableFolding();
+		}
+	}
+
+	/**
+	 * Re-read theme-derived colors for every open editor. Called after a style change
+	 * so the fold-triangle color (and any repaint-driven syntax colors) update live,
+	 * without needing to reopen tabs.
+	 */
+	public void refreshEditorStyles() {
+		if (mainfolder == null || mainfolder.isDisposed())
+			return;
+		for (CTabItem tab : mainfolder.getItems()) {
+			if (tab.getControl() instanceof EditorComposite) {
+				FoldingManager fm = ((EditorComposite) tab.getControl()).getFolding();
+				if (fm != null)
+					fm.refreshStyle();
+			}
+		}
+	}
+
 	private void setMainTitle(){
 		String server = "";
 		int sym;

--- a/com/repdev/OptionsShell.java
+++ b/com/repdev/OptionsShell.java
@@ -52,9 +52,9 @@ public class OptionsShell {
 	// Controls
 	private Spinner tabSpinner;
 	private Combo styleCombo, hour, minute;
-	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
+	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, enableFoldingLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
 	private Text  serverText, portText, errCheckPrefix, errCheckSuffix, liveSYMText, liveSYMColorText, sourceControlDir;
-	private Button varsButton, neverTerm, useSSO, devForgetBox, backupEnable, fileNameInTitle, hostInTitle, viewLineNumbers, useSourceControl;
+	private Button varsButton, neverTerm, useSSO, devForgetBox, backupEnable, fileNameInTitle, hostInTitle, viewLineNumbers, enableFolding, useSourceControl;
 	private String ssoPass = "";
 
 	public static void show(Shell parent) {
@@ -104,6 +104,11 @@ public class OptionsShell {
 				Config.setFileNameInTitle(fileNameInTitle.getSelection());
 				Config.setHostNameInTitle(hostInTitle.getSelection());
 				Config.setViewLineNumbers(viewLineNumbers.getSelection());
+				Config.setFoldingEnabled(enableFolding.getSelection());
+				// Disabling takes effect on open editors immediately (unfold + remove the
+				// fold gutter); enabling applies the next time an editor is opened.
+				if (!enableFolding.getSelection() && RepDevMain.mainShell != null)
+					RepDevMain.mainShell.disableFoldingOnOpenEditors();
 				Config.setLiveSym(Integer.parseInt(liveSYMText.getText()));
 				Config.setLiveSymColor(liveSYMColorText.getText());
 				Config.setUseSourceControl(useSourceControl.getSelection());
@@ -125,6 +130,8 @@ public class OptionsShell {
 				if(styleCombo.getSelectionIndex() > -1) {
 				    Config.setStyle(styleCombo.getItem(styleCombo.getSelectionIndex()));
 				    SyntaxHighlighter.loadStyle(Config.getStyle());
+				    if (RepDevMain.mainShell != null)
+				        RepDevMain.mainShell.refreshEditorStyles();
 				}
 				
 				// Project file backup
@@ -487,6 +494,11 @@ public class OptionsShell {
 		viewLineNumbers = new Button(editorGroup, SWT.CHECK);
 		viewLineNumbers.setSelection((Config.getViewLineNumbers()));
 
+		enableFoldingLabel = new Label(editorGroup, SWT.NONE);
+		enableFoldingLabel.setText("Enable code folding");
+		enableFolding = new Button(editorGroup, SWT.CHECK);
+		enableFolding.setSelection((Config.getFoldingEnabled()));
+
 		Group noErrorCheckGroup = new Group(editorOptions,SWT.NONE);
 		noErrorCheckGroup.setText("No Error Check for these Files");
 		layout = new FormLayout();
@@ -518,6 +530,7 @@ public class OptionsShell {
 			fileNameInTitle.setSelection(true);
 			hostInTitle.setSelection(true);
 			viewLineNumbers.setSelection(true);
+			enableFolding.setSelection(true);
 			RepDevMain.saveSettings();
 		}
 		FormData data = new FormData();
@@ -647,6 +660,18 @@ public class OptionsShell {
 		data.top = new FormAttachment(hostInTitle);
 		data.right = new FormAttachment(100);
 		viewLineNumbers.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(0);
+		data.top = new FormAttachment(viewLineNumbersLabel);
+		data.width = 163;
+		enableFoldingLabel.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(enableFoldingLabel);
+		data.top = new FormAttachment(viewLineNumbers);
+		data.right = new FormAttachment(100);
+		enableFolding.setLayoutData(data);
 
 		data = new FormData();
 		data.left = new FormAttachment(0);

--- a/styles/GhostRider.xml
+++ b/styles/GhostRider.xml
@@ -13,6 +13,10 @@
     <editor bgColor="#3F3F3F" fgColor="#F7E29F" line="#373737" token="#020000" font="Consolas" fontSize="11" />
     
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#B5A76A" shape="triangle" />
     
     <!-- Comments -->
     <comments fgColor="#7F9F7F" style="italic"/>

--- a/styles/blue.xml
+++ b/styles/blue.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$blue" fgColor="$blue" line="$blue" token="$blue" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$blue" />
     <variables fgColor="$blue" style="bold" />    
     <functions fgColor="$blue" style="bold" />    

--- a/styles/bright.xml
+++ b/styles/bright.xml
@@ -11,6 +11,10 @@
     <editor bgColor="FFFFFF" fgColor="000000" line="E8F2FE" token="C0C0C0" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#008000" />
     <variables fgColor="#000000" style="bold" />    
     <functions fgColor="#000080" style="bold" />    

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -12,6 +12,10 @@
     
 	<comments fgColor="#7F7F7F" />
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#A0A0A0" shape="plusminus" />
     <variables fgColor="#00BF00" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    
     <keywords fgColor="#0000FF" />

--- a/styles/default.xml
+++ b/styles/default.xml
@@ -11,6 +11,10 @@
     <editor bgColor="FFFFFF" fgColor="000000" line="E8F2FE" token="C0C0C0" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#000000" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    

--- a/styles/green.xml
+++ b/styles/green.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$green" fgColor="$green" line="$green" token="$green" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$green" />
     <variables fgColor="$green" style="bold" />    
     <functions fgColor="$green" style="bold" />    

--- a/styles/midnight.xml
+++ b/styles/midnight.xml
@@ -11,6 +11,10 @@
     <editor bgColor="#220044" fgColor="#ffffff" line="#444499" token="#FFDD00" font="Courier New" fontSize="10" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#9E90C0" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#CCCC00" style="bold" />    
     <functions fgColor="#CCCC00" style="bold" />    

--- a/styles/monochrome.xml
+++ b/styles/monochrome.xml
@@ -11,6 +11,10 @@
     <editor bgColor="F1F1F1" fgColor="1D1D1D" line="D5D5D5" token="ABABAB" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#6A6A6A" shape="triangle" />
     <comments fgColor="#969AA1" />
     <variables fgColor="#515151" style="bold" />    
     <functions fgColor="#515151" style="bold" />    

--- a/styles/random.xml
+++ b/styles/random.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$rand" fgColor="$rand" line="$rand" token="$rand" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$rand" />
     <variables fgColor="$rand" style="bold" />    
     <functions fgColor="$rand" style="bold" />    

--- a/styles/red.xml
+++ b/styles/red.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$red" fgColor="$red" line="$red" token="$red" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$red" />
     <variables fgColor="$red" style="bold" />    
     <functions fgColor="$red" style="bold" />    

--- a/styles/revised.xml
+++ b/styles/revised.xml
@@ -11,6 +11,10 @@
     <editor bgColor="F3F3F3" fgColor="300030" line="DEE6FF" token="A7A9BC" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#300030" style="bold" />    
     <functions fgColor="#4848E0" style="bold" />    

--- a/styles/snow.xml
+++ b/styles/snow.xml
@@ -11,6 +11,10 @@
     <editor bgColor="D1D7DF" fgColor="374280" line="94B7E1" token="99A9C9" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A6178" shape="triangle" />
     <comments fgColor="#7F8896" />
     <variables fgColor="#005CFF" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    

--- a/styles/sunset.xml
+++ b/styles/sunset.xml
@@ -12,6 +12,10 @@
     
 	<comments fgColor="#7F0000" />
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#A86A4A" shape="triangle" />
     <variables fgColor="#DEA46B" style="bold" />    
     <functions fgColor="#E20000" style="bold" />    
     <keywords fgColor="#E20000" />


### PR DESCRIPTION
Add a "folding" style element and an Editor Options toggle so the fold gutter's appearance and availability can be customized, building on thenew folding feature.

Style-driven appearance (FoldingManager, styles/*.xml):
- Fold icon color now reads <folding fgColor="..."/> from the active style instead of a hardcoded gray, resolved the same way as syntax colors and refreshed live on a theme change.
- Icon shape is selectable via shape="triangle" (default) or shape="plusminus" for boxed +/- markers.
- Always-on guide lines run from each expanded block's icon down to its end line (with an end foot), colored by <folding guideColor="..."/>, defaulting to the icon color dimmed toward the editor background.
- All bundled themes gain a <folding> element with instructional comments documenting these attributes; dark ships with plusminus as a default.

Enable/disable option (OptionsShell, Config, EditorComposite, MainShell):
- New "Enable code folding" checkbox under "Display line numbers", defaulting to enabled. When off, editors open without a FoldingManager, so icons, hotkeys, the fold gutter, and unfold-on-save all go inert via the existing null-guards.
- Disabling and saving unfolds all open editors and tears down their fold gutter live (FoldingManager now unregisters its listeners on dispose); enabling applies on next editor open to preserve listener ordering.
- The setting is stored inverted (foldingDisabled) so existing serialized configs, which predate the field, still default to enabled.