### PR TITLE
Add split editor functionality

### DIFF
--- a/com/repdev/Config.java
+++ b/com/repdev/Config.java
@@ -73,7 +73,12 @@ public class Config implements Serializable {
 	private boolean fileNameInWinTitle = true;
 	private boolean hostInTitle = true;
 	private boolean viewLineNumbers = true;
-	
+	// Stored inverted on purpose: existing repdev.conf files were serialized before this
+	// field existed, so on load Java sets it to the boolean default (false). Keeping the
+	// "disabled" sense means that default maps to folding ENABLED, matching the intended
+	// default for upgraders. Always go through get/setFoldingEnabled below.
+	private boolean foldingDisabled = false;
+
 	@SuppressWarnings("unused")
 	private int maxQueues = 3; //The largest value this slider goes up to, We should probably scrap this since the max value is 9999 and the error checking code is good enough now that it can detect what needs to be entered. In real life, this can also be non continous large ranges, which complicates things.
 							//UPDATE: Ok, this has been removed, however, you can't remove items from Serialized classes.
@@ -549,5 +554,13 @@ public class Config implements Serializable {
 
 	public static boolean getViewLineNumbers(){
 		return me.viewLineNumbers;
+	}
+
+	public static void setFoldingEnabled(boolean enabled){
+		me.foldingDisabled = !enabled;
+	}
+
+	public static boolean getFoldingEnabled(){
+		return !me.foldingDisabled;
 	}
 }

--- a/com/repdev/Config.java
+++ b/com/repdev/Config.java
@@ -58,7 +58,7 @@ public class Config implements Serializable {
 	 * different, then a popup will notify the user and will launch the OptionsShell so that
 	 * the users can config the new options.
 	 */
-	public final static int REVISION = 6; // Modify this everytime we add new options to prompt the user.
+	public final static int REVISION = 7; // Modify this everytime we add new options to prompt the user.
 	private int revision=-1;
 	private boolean windowMaximized;
 	private Point windowSize;
@@ -67,6 +67,8 @@ public class Config implements Serializable {
 	private int terminateHour;
 	private int terminateMinute;
 	private int sashHSize, sashVSize;
+	private int splitOrientation = 0;
+	private int splitWeight = 0;
 	private boolean backupProjectFiles = false;
 	private String noErrorCheckSuffix = ".PRO,.SET,.DEF,.INC";
 	private String noErrorCheckPrefix = "INC.";
@@ -409,6 +411,25 @@ public class Config implements Serializable {
 	 */
 	public static void setSashVSize(int size){
 		me.sashVSize = size;
+	}
+
+	/** @return SWT.HORIZONTAL or SWT.VERTICAL; defaults to HORIZONTAL when unset. */
+	public static int getSplitOrientation() {
+		return me.splitOrientation == 0 ? org.eclipse.swt.SWT.HORIZONTAL : me.splitOrientation;
+	}
+
+	public static void setSplitOrientation(int orientation) {
+		me.splitOrientation = orientation;
+	}
+
+	/** @return the primary pane's share out of 1000; defaults to an even split when unset. */
+	public static int getSplitWeight() {
+		int weight = me.splitWeight == 0 ? 500 : me.splitWeight;
+		return Math.max(50, Math.min(950, weight));
+	}
+
+	public static void setSplitWeight(int weight) {
+		me.splitWeight = weight;
 	}
 	
 	/**

--- a/com/repdev/EditorComposite.java
+++ b/com/repdev/EditorComposite.java
@@ -582,6 +582,30 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 	public FoldingManager getFolding(){
 		return folding;
 	}
+
+	/**
+	 * Live-disable code folding for this editor: unfold everything, then drop the fold
+	 * manager, its gutter column, and its listeners so the buffer reverts to plain-editor
+	 * behavior (no fold icons, hotkeys, or unfold-on-save). Called when the user turns off
+	 * "Enable code folding" and saves, so open tabs update without a reopen.
+	 *
+	 * Re-enabling only takes effect when an editor is (re)opened — the fold listener must
+	 * be registered ahead of the highlighter's for correct parser ordering (see the
+	 * construction comment above), which a live re-attach can't guarantee.
+	 */
+	public void disableFolding(){
+		if (folding == null) return;
+		if (folding.hasActiveFolds()) folding.expandAllSilent();
+		if (parser != null) parser.setHiddenTextProvider(null);
+		folding.dispose();
+		folding = null;
+		if (!txt.isDisposed()) {
+			// Shrink the gutter back (calcWidth now excludes the fold column) and repaint.
+			txt.setMargins(calcWidth(), 0, 0, 0);
+			txt.redraw();
+		}
+	}
+
 	private void buildGUI() {
 		setLayout(new FormLayout());
 
@@ -614,7 +638,7 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 		// is only correct once fold headerLines reflect the post-edit line
 		// numbering. Reversing this order causes parser state to drift one edit
 		// behind the buffer when folds are active.
-		if (file.getType() == FileType.REPGEN) {
+		if (file.getType() == FileType.REPGEN && Config.getFoldingEnabled()) {
 			folding = new FoldingManager(this, txt, parser);
 			parser.setHiddenTextProvider(folding);
 		}

--- a/com/repdev/EditorComposite.java
+++ b/com/repdev/EditorComposite.java
@@ -215,6 +215,15 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 		buildGUI();
 	}
 
+	/**
+	 * Re-points this editor at a different tab item. Required when the editor is moved
+	 * to another editor pane: the old CTabItem is disposed, and EditorComposite writes
+	 * the modified marker through this reference and disposes it on close. 
+	 */
+	public void setTabItem(CTabItem tabItem) {
+		this.tabItem = tabItem;
+	}
+
 	public boolean canUndo(){
 		return undos.size() > 0 && !snippetMode;
 	}
@@ -1496,8 +1505,6 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 	 */
 	private void gotoDefinitionImpl(boolean tryFoldExpansion){
 
-		CTabFolder mainfolder = RepDevMain.mainShell.getMainfolder();
-
 		HashMap<String, ArrayList<Token>> incTokenCache = parser.getIncludeTokenChache();
 		String selString=txt.getSelectionText();
 		if(selString.length() == 0)
@@ -1527,7 +1534,7 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 					return;
 			}
 			// Go through open files which include this file. Search for Variables/Procedures and goto.
-			for(CTabItem tf : mainfolder.getItems()){
+			for(CTabItem tf : RepDevMain.mainShell.getPanes().allItems()){
 				if(tf.getControl() instanceof EditorComposite) {
 					EditorComposite ec = ((EditorComposite) tf.getControl());
 					incTokenCache = ec.parser.getIncludeTokenChache();
@@ -2058,7 +2065,6 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 			parser.parseIncludes();
 
 		//Check other open tabs, and if needed set the flag to reparse their includes
-		CTabFolder folder = (CTabFolder)getParent();
 		Object loc;
 
 		if( file.isLocal())
@@ -2066,7 +2072,7 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 		else
 			loc = file.getSym();
 
-		for( CTabItem cur : folder.getItems()){
+		for( CTabItem cur : RepDevMain.mainShell.getPanes().allItems()){
 			if( cur.getControl() == null || !(cur.getControl() instanceof EditorComposite) )
 				continue;
 
@@ -2096,6 +2102,7 @@ public class EditorComposite extends Composite implements TabTextEditorView {
 		else
 			loc = file.getSym();
 
+		// Deliberately folder-local: openFile de-duplicates tabs across panes, and getParent() follows setParent moves.
 		for( CTabItem cur : folder.getItems())
 			if( cur.getData("file") != null && ((SymitarFile)cur.getData("file")).equals(file) && cur.getData("loc").equals(loc)  )
 				if( modified && ( cur.getData("modified") == null || !((Boolean)cur.getData("modified")))){

--- a/com/repdev/EditorPaneManager.java
+++ b/com/repdev/EditorPaneManager.java
@@ -1,0 +1,735 @@
+/**
+ *  RepDev - RepGen IDE for Symitar
+ *  Copyright (C) 2007  Jake Poznanski, Ryan Schultz, Sean Delaney
+ *  http://repdev.org/ <support@repdev.org>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.repdev;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabFolder2Adapter;
+import org.eclipse.swt.custom.CTabFolderEvent;
+import org.eclipse.swt.custom.CTabItem;
+import org.eclipse.swt.custom.SashForm;
+import org.eclipse.swt.events.DisposeEvent;
+import org.eclipse.swt.events.DisposeListener;
+import org.eclipse.swt.events.MenuAdapter;
+import org.eclipse.swt.events.MenuEvent;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Cursor;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.graphics.Rectangle;
+import org.eclipse.swt.layout.FillLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Menu;
+import org.eclipse.swt.widgets.MenuItem;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Sash;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
+
+/**
+ * Owns the editor area: a SashForm holding one or two CTabFolders, and the knowledge of
+ * which folder is currently active. All per-folder wiring lives in createFolder() so both
+ * panes are built from one source and cannot drift apart.
+ *
+ * Secondary is null until the user first moves a tab across, and is disposed again when its
+ * last tab closes.
+ */
+public class EditorPaneManager {
+	private final SashForm sash;
+	private final MainShell shell;
+	private CTabFolder primary;
+	private CTabFolder secondary;
+	private CTabFolder active;
+
+	public EditorPaneManager(Composite parent, MainShell shell) {
+		this.shell = shell;
+		this.sash = new SashForm(parent, Config.getSplitOrientation());
+		ensureTabColors();
+		this.primary = createFolder();
+		this.active = primary;
+
+		// SWT events do not propagate child -> parent, so a listener on the CTabFolder never
+		// sees focus landing in the StyledText it hosts. A display filter plus a walk up the
+		// parent chain is the only reliable way i found to know which pane the user is 
+		// actually working in.
+		final Listener focusFilter = new Listener() {
+			public void handleEvent(Event e) {
+				if (!(e.widget instanceof Control))
+					return;
+				CTabFolder owner = folderOf((Control) e.widget);
+				if (owner != null)
+					active = owner;
+			}
+		};
+		sash.getDisplay().addFilter(SWT.FocusIn, focusFilter);
+		sash.addDisposeListener(new DisposeListener() {
+			public void widgetDisposed(DisposeEvent e) {
+				if (!sash.getDisplay().isDisposed())
+					sash.getDisplay().removeFilter(SWT.FocusIn, focusFilter);
+			}
+		});
+	}
+
+	/** Saves the primary pane's current share while preserving a usable secondary pane. */
+	private void captureSplitWeight() {
+		int[] w = sash.getWeights();
+		if (w.length == 2 && w[0] + w[1] > 0) {
+			int weight = (int) (1000L * w[0] / (w[0] + w[1]));
+			Config.setSplitWeight(Math.max(50, Math.min(950, weight)));
+		}
+	}
+
+	/** The folder that last had focus. Never null. */
+	public CTabFolder active() {
+		if (active == null || active.isDisposed())
+			active = primary;
+		return active;
+	}
+
+	public boolean isSplit() {
+		return secondary != null && !secondary.isDisposed();
+	}
+
+	/** @param swtDir SWT.HORIZONTAL for side-by-side panes, SWT.VERTICAL for stacked. */
+	public void setOrientation(int swtDir) {
+		sash.setOrientation(swtDir);
+		sash.layout();
+	}
+
+	public int getOrientation() {
+		return sash.getOrientation();
+	}
+
+	/** Moves keyboard focus to the opposite pane's selected editor, if there is one. */
+	public void focusOtherView() {
+		if (!isSplit())
+			return;
+		CTabFolder target = active() == secondary ? primary : secondary;
+		CTabItem sel = target.getSelection();
+		if (sel == null)
+			return;
+		boolean focused;
+		if (sel.getControl() instanceof TabTextView)
+			focused = ((TabTextView) sel.getControl()).getStyledText().setFocus();
+		else
+			focused = target.setFocus();
+		if (focused)
+			active = target;
+	}
+
+	/**
+	 * Snapshot of every tab in both panes. A copy, so callers caan dispose items while
+	 * iterating, which close-all and close-others both do.
+	 */
+	public List<CTabItem> allItems() {
+		List<CTabItem> out = new ArrayList<CTabItem>();
+		if (primary != null && !primary.isDisposed())
+			for (CTabItem i : primary.getItems())
+				out.add(i);
+		if (secondary != null && !secondary.isDisposed())
+			for (CTabItem i : secondary.getItems())
+				out.add(i);
+		return out;
+	}
+
+	/** Finds an already-open file in either pane, or null. */
+	public CTabItem findItem(SymitarFile file, Object loc) {
+		for (CTabItem c : allItems())
+			if (c.getData("file") != null && c.getData("file").equals(file)
+					&& c.getData("loc") != null && c.getData("loc").equals(loc))
+				return c;
+		return null;
+	}
+
+	/** Finds an already-open sequence view in either pane, or null. */
+	public CTabItem findItem(Sequence seq, int sym) {
+		for (CTabItem c : allItems())
+			if (c.getData("seq") != null && c.getData("seq") == seq
+					&& c.getData("sym") != null && ((Integer) c.getData("sym")) == sym)
+				return c;
+		return null;
+	}
+
+	/** Creates a tab in the active pane. */
+	public CTabItem newItem(int style) {
+		return createItem(active(), style);
+	}
+
+	/** Creates a tab whose disposal schedules a deferred empty-pane collapse. */
+	private CTabItem createItem(final CTabFolder folder, int style) {
+		return watchForDispose(new CTabItem(folder, style), folder);
+	}
+
+	/** Creates an indexed tab whose disposal schedules a deferred empty-pane collapse. */
+	private CTabItem createItem(final CTabFolder folder, int style, int index) {
+		return watchForDispose(new CTabItem(folder, style, index), folder);
+	}
+
+	private CTabItem watchForDispose(CTabItem item, final CTabFolder folder) {
+		item.addDisposeListener(new DisposeListener() {
+			public void widgetDisposed(DisposeEvent e) {
+				collapseIfEmpty(folder);
+			}
+		});
+		return item;
+	}
+
+	/** Creates the second pane on demand and restores the saved divider position. */
+	private CTabFolder ensureSecondary() {
+		if (secondary == null || secondary.isDisposed()) {
+			secondary = createFolder();
+			int w = Config.getSplitWeight();
+			sash.setWeights(new int[] { w, 1000 - w });
+			sash.layout();
+			for (Control child : sash.getChildren())
+				if (child instanceof Sash && child.getData("splitWeightListener") == null) {
+					child.setData("splitWeightListener", Boolean.TRUE);
+					child.addListener(SWT.Selection, new Listener() {
+						public void handleEvent(Event e) {
+							if (e.detail != SWT.DRAG)
+								captureSplitWeight();
+						}
+					});
+				}
+		}
+		return secondary;
+	}
+
+	/**
+	 * Returns to one pane after a folder empties. If the primary empties while the secondary
+	 * still has tabs, the secondary is promoted to primary. Deferred with asyncExec so this
+	 * never runs while allItems() is being iterated or while SWT is dispatching a close event.
+	 */
+	private void collapseIfEmpty(final CTabFolder f) {
+		if (f == null || f.isDisposed() || sash.isDisposed() || sash.getDisplay().isDisposed())
+			return;
+		sash.getDisplay().asyncExec(new Runnable() {
+			public void run() {
+				if (sash.isDisposed() || f.isDisposed() || f.getItemCount() != 0)
+					return;
+				if (f == secondary) {
+					f.dispose();
+					secondary = null;
+					active = primary;
+					sash.layout();
+				} else if (f == primary && secondary != null && !secondary.isDisposed()
+						&& secondary.getItemCount() > 0) {
+					CTabFolder surviving = secondary;
+					primary = surviving;
+					secondary = null;
+					active = primary;
+					f.dispose();
+					sash.layout();
+				}
+			}
+		});
+	}
+
+	public boolean canMove(CTabItem src) {
+		if (src == null || src.isDisposed() || src.getControl() == null)
+			return false;
+		return !(src.getParent() == primary && primary.getItemCount() == 1 && secondary == null);
+	}
+
+	/**
+	 * Moves a tab to the opposite pane, preserving the live editor control, undo history, 
+	 * fold state, parser state, caret and scroll position.
+	 */
+	public void moveToOtherView(CTabItem src) {
+		if (!canMove(src))
+			return;
+
+		CTabFolder source = src.getParent();
+		CTabFolder target = source == secondary ? primary : secondary;
+		boolean createdTarget = false;
+		if (target == null || target.isDisposed()) {
+			target = ensureSecondary();
+			createdTarget = true;
+		}
+		Control c = src.getControl();
+
+		if (!c.setParent(target)) {
+			if (createdTarget)
+				collapseIfEmpty(target);
+			MessageBox mb = new MessageBox(sash.getShell(), SWT.ICON_ERROR | SWT.OK);
+			mb.setText("Move Failed");
+			mb.setMessage("This tab could not be moved to the other view.");
+			mb.open();
+			return;
+		}
+
+
+		CTabItem dst = createItem(target, SWT.CLOSE);
+		MainShell.copyTabState(src, dst);
+
+		// Order here is load-bearing, and every step is doing something non-obvious.
+		//
+		// 1. src.setControl(null) must happen BEFORE the control is attached to dst.
+		//    Its purpose is to stop src.dispose() from destroying the live editor, but
+		//    CTabItem.setControl(null) also calls setVisible(false) on whatever control the
+		//    item still references, and src still references this one. Done after the
+		//    attach, it hides the editor just showed, and nothing puts it back:
+		//    setSelection early-returns via showItem() when the item is already selected,
+		//    so with a single tab in the pane there is no selection CHANGE to re-show it.
+		//    That was causing blank tabs when moving the initial doc to the pane.
+		// 2. target.setSelection(dst) must happen BEFORE dst.setControl(c), because
+		//    setControl only sizes and shows the control when its item is the folder's
+		//    current selection; otherwise it hides it. A pane created by this move has no
+		//    selection yet, as CTabFolder does not auto-select its first item.
+		//
+		// So... detach from src, destroy src, select dst, and attach last... leaving the
+		// showing operation as the final thing done to the control.
+		src.setControl(null);
+		src.dispose();
+
+		target.setSelection(dst);
+		dst.setControl(c);
+
+		if (c instanceof EditorComposite)
+			((EditorComposite) c).setTabItem(dst);
+		else if (c instanceof ReportComposite)
+			((ReportComposite) c).setTabItem(dst);
+
+		if (source.getSelection() != null)
+			source.notifyListeners(SWT.Selection, new Event());
+		active = target;
+		shell.setMainFolderSelection(dst);
+		target.notifyListeners(SWT.Selection, new Event());
+		if (c instanceof TabTextView)
+			((TabTextView) c).getStyledText().setFocus();
+
+		collapseIfEmpty(source);
+		shell.setMainTitle();
+		sash.layout();
+	}
+
+	/** Walks up the parent chain to the editor pane containing this control, or null. */
+	private CTabFolder folderOf(Control c) {
+		while (c != null && !c.isDisposed()) {
+			if (c == primary)
+				return primary;
+			if (secondary != null && c == secondary)
+				return secondary;
+			c = c.getParent();
+		}
+		return null;
+	}
+
+	/** Which pane, if any, sits under this display-relative point. */
+	private CTabFolder folderAt(Point displayPoint) {
+		if (secondary != null && !secondary.isDisposed()
+				&& secondary.getBounds().contains(secondary.getParent().toControl(displayPoint)))
+			return secondary;
+		if (!primary.isDisposed()
+				&& primary.getBounds().contains(primary.getParent().toControl(displayPoint)))
+			return primary;
+		return null;
+	}
+
+	private void ensureTabColors() {
+		// XP Theme Color Tabs With Gradient start
+		  try {
+				  File file = new File("styles\\" + Config.getStyle() + ".xml");
+				  DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+				  DocumentBuilder db = dbf.newDocumentBuilder();
+				  Document doc = db.parse(file);
+				  doc.getDocumentElement().normalize();
+				  NodeList nodeLst = doc.getElementsByTagName("tabStyle");
+				  if(nodeLst.getLength() > 0){
+					  NamedNodeMap attributes = nodeLst.item(0).getAttributes();
+					  shell.titleForeColor = MainShell.HextoColor(attributes.getNamedItem("fgColor").getTextContent());
+					  shell.titleBackColor1 = MainShell.HextoColor(attributes.getNamedItem("bgcolor1").getTextContent());
+					  shell.titleBackColor2 = MainShell.HextoColor(attributes.getNamedItem("bgcolor2").getTextContent());
+				  }
+			  } catch (Exception e) {
+				  e.printStackTrace();
+			  }
+			  if(shell.titleForeColor == null || shell.titleBackColor1 == null || shell.titleBackColor2 == null){
+				shell.titleForeColor = shell.display.getSystemColor(SWT.COLOR_TITLE_FOREGROUND);
+				shell.titleBackColor1 = shell.display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND);
+				shell.titleBackColor2 = shell.display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT);
+			  }
+		// XP Theme Color Tabs With Gradient End
+	}
+
+	private CTabFolder createFolder() {
+		final CTabFolder folder = new CTabFolder(sash, SWT.TOP | SWT.BORDER);
+		final Cursor cursor = new Cursor(shell.display, SWT.CURSOR_SIZEALL);
+		folder.setLayout(new FillLayout());
+		folder.setSimple(false);
+
+		final Menu tabContextMenu = new Menu(folder);
+		folder.setMenu(tabContextMenu);
+		folder.addDisposeListener(new DisposeListener() {
+			public void widgetDisposed(DisposeEvent e) {
+				if (!cursor.isDisposed())
+					cursor.dispose();
+				if (!tabContextMenu.isDisposed())
+					tabContextMenu.dispose();
+			}
+		});
+
+		folder.setSelectionForeground(shell.titleForeColor);
+		folder.setSelectionBackground(new Color[] { shell.titleBackColor1, shell.titleBackColor2 }, new int[] { 100 }, true);
+
+		// Drag tab code start
+		// Close tab with middle mouse code start
+		// Tab history code start
+		Listener listener = new Listener() {
+			boolean drag = false;
+			boolean exitDrag = false;
+			CTabItem dragItem;
+			public void handleEvent(Event e) {
+				Point p = new Point(e.x, e.y);
+				if (e.type == SWT.DragDetect) {
+					p = folder.toControl(shell.display.getCursorLocation()); // see bug 43251
+				}
+				switch (e.type) {
+				case SWT.MouseDown: {
+					  if (e.button == 2){ // Close tab with middle click (or mouse wheel click)
+							if (shell.confirmClose(folder.getSelection())) {
+								shell.clearErrorAndTaskList(folder.getSelection());
+								folder.getSelection().dispose();
+								shell.setLineColumn();
+							}
+					  }
+					  else{ // Record that tab selection was changed
+						  shell.addToTabHistory();
+						  //addToNavHistory(((EditorComposite)item.getControl()).getFile(),line);
+					  }
+					  break;
+				}
+				case SWT.DragDetect: {
+					CTabItem item = folder.getItem(p);
+					if (item == null)
+						return;
+					//e.image = shell.display.getSystemImage(SWT.ICON_WARNING);
+
+					drag = true;
+					exitDrag = false;
+					dragItem = item;
+					folder.setCursor(cursor);
+					break;
+				}
+				case SWT.MouseEnter:
+					if (exitDrag) {
+						exitDrag = false;
+						drag = e.button != 0;
+					}
+					break;
+				case SWT.MouseExit:
+					if (drag) {
+						folder.setInsertMark(null, false);
+						exitDrag = true;
+						// Deliberately keep drag = true: the pointer may be crossing into
+						// the sibling pane, which MouseUp handles above.
+					}
+					break;
+				case SWT.MouseUp: {
+					if (!drag)
+						return;
+					folder.setInsertMark(null, false);
+					shell.drawDestTabRect(null);
+					CTabFolder over = folderAt(folder.toDisplay(p));
+					if (over != folder) {
+						if (over != null && canMove(dragItem))
+							moveToOtherView(dragItem);
+						drag = false;
+						exitDrag = false;
+						dragItem = null;
+						folder.setCursor(null);
+						return;
+					}
+					CTabItem item = folder.getItem(p);
+					if (item != null) {
+						Rectangle sourceRect = dragItem.getBounds();
+						Rectangle destRect = item.getBounds();
+						boolean after = sourceRect.x < destRect.x;
+						int index = folder.indexOf(item);
+						index = after ? index + 1 : index - 0;
+						index = Math.max(0, index);
+						CTabItem newItem = createItem(folder, SWT.CLOSE, index);
+						//newItem.setText("new tab item");
+						MainShell.copyTabState(dragItem, newItem);
+						Control c = dragItem.getControl();
+						newItem.setControl(c);
+						dragItem.setControl(null);
+						dragItem.dispose();
+						shell.setMainFolderSelection(newItem);
+						if (folder.getSelection() != null && (folder.getSelection().getControl()) instanceof EditorComposite)
+							((EditorComposite) folder.getSelection().getControl()).getStyledText().setFocus();
+						shell.setMainTitle();
+					}
+					drag = false;
+					exitDrag = false;
+					dragItem = null;
+					folder.setCursor(null);
+					break;
+				}
+				case SWT.MouseMove: {
+					if (!drag)
+						return;
+					CTabItem item = folder.getItem(p);
+					if (item == null) {
+						folder.setInsertMark(null, false);
+						shell.drawDestTabRect(null);
+						return;
+					}
+					Rectangle rect = item.getBounds();
+					boolean after = p.x > rect.x + rect.width / 2;
+					folder.setInsertMark(item, after);
+					shell.drawDestTabRect(item);
+//				    // Workaround for bug #32846
+//				    if (item == -1) {
+//				    	folder.redraw();
+//				    }
+					break;
+				}
+				}
+			}
+		};
+		folder.addListener(SWT.DragDetect, listener);
+		folder.addListener(SWT.MouseUp, listener);
+		folder.addListener(SWT.MouseMove, listener);
+		folder.addListener(SWT.MouseExit, listener);
+		folder.addListener(SWT.MouseEnter, listener);
+		folder.addListener(SWT.MouseDown, listener);
+
+		// Drag tab code end
+
+		folder.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelection() != null && (folder.getSelection().getControl()) instanceof EditorComposite) {
+					SymitarFile file = ((EditorComposite) folder.getSelection().getControl()).getFile();
+					if (file.getType() != FileType.REPGEN || file.isLocal())
+						shell.install.setEnabled(false);
+					else
+						shell.install.setEnabled(true);
+
+					if (file.getType() != FileType.REPGEN || file.isLocal())
+						shell.run.setEnabled(false);
+					else
+						shell.run.setEnabled(true);
+
+					if ((file.getType() == FileType.REPGEN)||(file.getType() == FileType.LETTER)||(file.getType() == FileType.HELP)||(file.getType() == FileType.DATA))
+						shell.hltoggle.setEnabled(true);
+
+					shell.savetb.setEnabled(true);
+					shell.print.setEnabled(true);
+				} else {
+					shell.print.setEnabled(true);
+					shell.savetb.setEnabled(false);
+					shell.run.setEnabled(false);
+					shell.install.setEnabled(false);
+					shell.hltoggle.setEnabled(false);
+				}
+			}
+		});
+
+		final MenuItem closeTab = new MenuItem(tabContextMenu, SWT.NONE);
+		closeTab.setText("Close Tab");
+		closeTab.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelectionIndex() != -1) {
+					if (shell.confirmClose(folder.getSelection())) {
+						shell.clearErrorAndTaskList(folder.getSelection());
+						folder.getSelection().dispose();
+						shell.setLineColumn();
+					}
+				}
+			}
+
+		});
+
+		final MenuItem closeOthers = new MenuItem(tabContextMenu, SWT.NONE);
+		closeOthers.setText("Close Others");
+		closeOthers.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				CTabItem selection = folder.getSelection();
+				if (selection != null && allItems().size() > 1) {
+
+					for (CTabItem item : allItems())
+						if (!item.equals(selection))
+							if (shell.confirmClose(item)) {
+								shell.clearErrorAndTaskList(item);
+								item.dispose();
+							}
+
+				}
+			}
+
+		});
+
+		final MenuItem closeAll = new MenuItem(tabContextMenu, SWT.NONE);
+		closeAll.setText("Close All");
+		closeAll.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (allItems().size() >= 1) {
+
+					for (CTabItem item : allItems())
+						if (shell.confirmClose(item)) {
+							shell.clearErrorAndTaskList(item);
+							item.dispose();
+						}
+
+				}
+			}
+
+		});
+
+		final MenuItem separator = new MenuItem(tabContextMenu, SWT.SEPARATOR);
+
+		final MenuItem save = new MenuItem(tabContextMenu, SWT.None);
+		save.setText("Save");
+		save.addSelectionListener(new SelectionAdapter() {
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelectionIndex() != -1 && (folder.getSelection().getControl() instanceof EditorComposite)) {
+					((EditorComposite) folder.getSelection().getControl()).saveFile(true);
+				} else {
+					System.out.println("Error:  Can not save non-EditorComposite File");
+				}
+			}
+		});
+
+		final MenuItem saveAll = new MenuItem(tabContextMenu, SWT.NONE);
+		saveAll.setText("Save All");
+		saveAll.addSelectionListener(new SelectionAdapter() {
+
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				shell.saveAllRepgens();
+			}
+
+		});
+
+		final MenuItem installRepgen = new MenuItem(tabContextMenu, SWT.NONE);
+		installRepgen.setText("Install");
+		installRepgen.addSelectionListener(new SelectionAdapter() {
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelectionIndex() != -1 && (folder.getSelection().getControl() instanceof EditorComposite)) {
+
+					((EditorComposite) folder.getSelection().getControl()).installRepgen(true);
+				}
+			}
+		});
+
+		final MenuItem moveToOther = new MenuItem(tabContextMenu, SWT.NONE);
+		moveToOther.setText("&Move to Other View");
+		moveToOther.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelectionIndex() != -1)
+					moveToOtherView(folder.getSelection());
+			}
+		});
+
+		tabContextMenu.addMenuListener(new MenuAdapter() {
+
+			@Override
+			public void menuShown(MenuEvent e) {
+				boolean flag = folder.getSelectionIndex() != -1;
+
+				closeTab.setEnabled(flag);
+				closeAll.setEnabled(flag);
+
+				save
+				.setEnabled((flag && (folder.getSelection().getControl() instanceof EditorComposite) && folder.getSelection().getData("modified") != null && (Boolean) folder
+						.getSelection().getData("modified")));
+
+				saveAll.setEnabled(flag);
+				installRepgen.setEnabled(flag && (folder.getSelection().getControl() instanceof EditorComposite)
+						&& !((EditorComposite) folder.getSelection().getControl()).getFile().isLocal());
+
+				closeOthers.setEnabled(flag && allItems().size() > 1);
+				moveToOther.setEnabled(flag && canMove(folder.getSelection()));
+
+			}
+
+		});
+
+		// Make the find/replace box know which thing we are looking through, if
+		// the window is open as we switch tabs
+		folder.addSelectionListener(new SelectionAdapter() {
+			public void widgetSelected(SelectionEvent e) {
+				if (folder.getSelection() != null && folder.getSelection().getControl() instanceof EditorComposite)
+					shell.findReplaceShell.attach(((EditorComposite) folder.getSelection().getControl()).getStyledText(), true);
+				else if (folder.getSelection() != null && folder.getSelection().getControl() instanceof ReportComposite)
+					shell.findReplaceShell.attach(((ReportComposite) folder.getSelection().getControl()).getStyledText(), false);
+
+				// show active repgen's title in the window title
+				shell.setMainTitle();
+			}
+
+		});
+
+		folder.addSelectionListener(new SelectionAdapter(){
+			public void widgetSelected(SelectionEvent e){
+				if (folder.getSelection().getControl() instanceof EditorComposite){
+					if(((EditorComposite)folder.getSelection().getControl()).getHighlight()){
+						shell.hltoggle.setImage(RepDevMain.smallHighlight);
+					}else{
+						shell.hltoggle.setImage(RepDevMain.smallHighlightGrey);
+					}
+				}
+			}
+		});
+
+		folder.addCTabFolder2Listener(new CTabFolder2Adapter() {
+			public void close(CTabFolderEvent event) {
+				event.doit = shell.confirmClose((CTabItem) event.item);
+				shell.setLineColumn();
+
+				if (event.doit) {
+					if( folder.getSelection() == event.item )
+						shell.getShell().setText(RepDevMain.NAMESTR); // remove active repgen name from title
+					shell.clearErrorAndTaskList((CTabItem) event.item);
+				}
+
+				if (allItems().size() == 1) {
+					shell.install.setEnabled(false);
+					shell.savetb.setEnabled(false);
+					shell.hltoggle.setEnabled(false);
+					shell.print.setEnabled(false);
+					shell.run.setEnabled(false);
+				}
+			}
+		});
+		return folder;
+	}
+}

--- a/com/repdev/FoldingManager.java
+++ b/com/repdev/FoldingManager.java
@@ -19,6 +19,7 @@
 
 package com.repdev;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -101,7 +102,18 @@ public class FoldingManager implements HiddenTextProvider {
 	private final ArrayList<FoldRegion> folded = new ArrayList<FoldRegion>();
 	private final ArrayList<FoldableRange> foldable = new ArrayList<FoldableRange>();
 
-	private final Color markerColor;
+	/** Fallback triangle color when the active style declares no <folding fgColor="..."/>. */
+	private static final RGB DEFAULT_MARKER_RGB = new RGB(90, 90, 90);
+	/** Marker glyph styles selectable via the style's {@code <folding shape="..."/>} attribute. */
+	private static final String SHAPE_TRIANGLE = "triangle";
+	private static final String SHAPE_PLUSMINUS = "plusminus";
+	// Not final: refreshStyle() disposes and recreates these when the theme changes.
+	private Color markerColor;
+	// Always-on vertical guide line drawn from each expanded block's icon down to its end.
+	private Color guideColor;
+	// Which glyph to paint in the fold gutter. Defaults to triangles; a style may opt
+	// into boxed +/- markers with shape="plusminus".
+	private String markerShape = SHAPE_TRIANGLE;
 	private boolean inFoldOp = false;
 	// True while a fold-all is iterating. Individual collapse/expand ops suppress
 	// their per-op parser.reparseAll() + recomputeRanges() (which triggers the
@@ -119,9 +131,74 @@ public class FoldingManager implements HiddenTextProvider {
 		this.editor = editor;
 		this.txt = txt;
 		this.parser = parser;
-		this.markerColor = new Color(txt.getDisplay(), new RGB(90, 90, 90));
+		loadFoldingStyle();
 		install();
 	}
+
+	/**
+	 * Read the fold marker's color, glyph shape, and guide-line color from the active
+	 * style's {@code <folding fgColor="..." shape="..." guideColor="..."/>} element in one
+	 * parse, and (re)build {@link #markerColor} / {@link #markerShape} / {@link #guideColor}.
+	 * Missing or malformed values fall back to {@link #DEFAULT_MARKER_RGB},
+	 * {@link #SHAPE_TRIANGLE}, and — for the guide — a dimmed blend of the marker color
+	 * toward the editor background, so older or custom style files keep working. Mirrors
+	 * how SyntaxHighlighter resolves per-element style values.
+	 */
+	private void loadFoldingStyle() {
+		RGB rgb = DEFAULT_MARKER_RGB;
+		RGB guideRgb = null;
+		RGB bg = null;
+		String shape = SHAPE_TRIANGLE;
+		try {
+			Style style = new Style(new File("styles\\" + Config.getStyle() + ".xml"));
+			RGB c = style.getColor("folding", "fgColor");
+			if (c != null) rgb = c;
+			String s = style.getValue("folding", "shape");
+			if (s != null && s.trim().length() > 0) shape = s.trim().toLowerCase();
+			guideRgb = style.getColor("folding", "guideColor"); // explicit override; may be null
+			bg = style.getColor("editor", "bgColor");           // used to dim the default guide
+		} catch (Exception ex) {
+			// Malformed/absent style file — keep the default gray triangle.
+		}
+		if (guideRgb == null) guideRgb = dimToward(rgb, bg);
+
+		Color oldMarker = markerColor;
+		Color oldGuide = guideColor;
+		markerColor = new Color(txt.getDisplay(), rgb);
+		guideColor = new Color(txt.getDisplay(), guideRgb);
+		if (oldMarker != null && !oldMarker.isDisposed()) oldMarker.dispose();
+		if (oldGuide != null && !oldGuide.isDisposed()) oldGuide.dispose();
+		markerShape = shape;
+	}
+
+	/**
+	 * Default fold-guide color: the marker color blended halfway toward the editor
+	 * background so the always-on guide line reads as a dimmed version of the icon.
+	 * Falls back to a mid-gray blend when the background is unknown (e.g. randomized styles).
+	 */
+	private static RGB dimToward(RGB c, RGB bg) {
+		RGB target = (bg != null) ? bg : new RGB(128, 128, 128);
+		return new RGB((c.red + target.red) / 2,
+		               (c.green + target.green) / 2,
+		               (c.blue + target.blue) / 2);
+	}
+
+	/**
+	 * Re-read the fold marker's color and shape from the current style and repaint. Called
+	 * after a theme change so open editors update live, matching how syntax colors refresh.
+	 */
+	public void refreshStyle() {
+		if (txt.isDisposed()) return;
+		loadFoldingStyle();
+		txt.redraw();
+	}
+
+	// Listener references retained so dispose() can unregister them — required when
+	// folding is torn down live (user disables the feature) rather than only at editor
+	// close, so a detached manager stops receiving edit/paint/click events.
+	private ExtendedModifyListener modifyListener;
+	private PaintListener paintListener;
+	private MouseAdapter mouseListener;
 
 	private void install() {
 		// Registered first so headerLine shifts complete before downstream
@@ -129,19 +206,21 @@ public class FoldingManager implements HiddenTextProvider {
 		// Without this ordering, parser-side canonical-source reassembly sees
 		// stale headerLine values for one edit cycle and reinserts hidden
 		// blocks at the wrong offset — corrupting model-coord parse state.
-		txt.addExtendedModifyListener(new ExtendedModifyListener() {
+		modifyListener = new ExtendedModifyListener() {
 			public void modifyText(ExtendedModifyEvent event) {
 				onTextModified(event);
 			}
-		});
+		};
+		txt.addExtendedModifyListener(modifyListener);
 
-		txt.addPaintListener(new PaintListener() {
+		paintListener = new PaintListener() {
 			public void paintControl(PaintEvent e) {
 				paintMarkers(e);
 			}
-		});
+		};
+		txt.addPaintListener(paintListener);
 
-		txt.addMouseListener(new MouseAdapter() {
+		mouseListener = new MouseAdapter() {
 			public void mouseDown(MouseEvent e) {
 				if (e.button != 1 || txt.getLineHeight() == 0) return;
 				int gutter = editor.calcWidth();
@@ -152,7 +231,8 @@ public class FoldingManager implements HiddenTextProvider {
 				if (line < 0 || line >= txt.getLineCount()) return;
 				toggleAtLine(line);
 			}
-		});
+		};
+		txt.addMouseListener(mouseListener);
 	}
 
 	/**
@@ -951,6 +1031,35 @@ public class FoldingManager implements HiddenTextProvider {
 		GC gc = e.gc;
 		Color oldFg = gc.getForeground();
 		Color oldBg = gc.getBackground();
+
+		// Always-on fold guide lines: a dimmed vertical line from each expanded block's
+		// icon down to its end line, capped with a short foot (└). Drawn before the glyphs
+		// so the icons sit on top. Iterates the foldable list directly — not just the
+		// visible rows — so the guide still shows when its header has scrolled off the top;
+		// the span is clipped to the client area in pixel space.
+		gc.setForeground(guideColor);
+		int lastLine = txt.getLineCount() - 1;
+		for (int i = 0; i < foldable.size(); i++) {
+			FoldableRange fr = foldable.get(i);
+			int endLine = fr.endLine;
+			if (endLine > lastLine) endLine = lastLine;
+			if (endLine <= fr.headerLine) continue;
+			int yHead, yEnd;
+			try {
+				yHead = txt.getLocationAtOffset(txt.getOffsetAtLine(fr.headerLine)).y;
+				yEnd = txt.getLocationAtOffset(txt.getOffsetAtLine(endLine)).y;
+			} catch (IllegalArgumentException ex) { continue; }
+			int yStart = yHead + (lh / 2) + 7; // just below the header glyph
+			int yStop = yEnd + (lh / 2);       // middle of the end row
+			if (yStop <= yStart) continue;
+			boolean endVisible = (yStop >= 0 && yStop <= clientH);
+			int a = Math.max(yStart, 0);
+			int b = Math.min(yStop, clientH);
+			if (b <= a) continue;
+			gc.drawLine(cx, a, cx, b);
+			if (endVisible) gc.drawLine(cx, b, cx + 4, b); // foot marking the block end
+		}
+
 		gc.setForeground(markerColor);
 		gc.setBackground(markerColor);
 
@@ -963,15 +1072,29 @@ public class FoldingManager implements HiddenTextProvider {
 				y = txt.getLocationAtOffset(txt.getOffsetAtLine(line)).y;
 			} catch (IllegalArgumentException ex) { continue; }
 			int cy = y + (lh / 2);
-			int s = 6;
-			if (isFolded) {
-				// Right-pointing triangle (region is collapsed)
-				int[] pts = { cx - (s - 2), cy - s, cx + (s - 1), cy, cx - (s - 2), cy + s };
-				gc.fillPolygon(pts);
+			if (SHAPE_PLUSMINUS.equals(markerShape)) {
+				// Boxed +/- : a bordered square with a horizontal bar (expanded, "-"),
+				// plus a vertical bar when collapsed to form "+". Only the outline and
+				// bars are stroked in markerColor; the box interior stays the editor
+				// background (drawRectangle/drawLine use the foreground only).
+				int half = 5;   // box half-size → 10px square
+				int inset = 2;  // bar padding inside the box
+				gc.drawRectangle(cx - half, cy - half, half * 2, half * 2);
+				gc.drawLine(cx - half + inset, cy, cx + half - inset, cy);
+				if (isFolded)
+					gc.drawLine(cx, cy - half + inset, cx, cy + half - inset);
 			} else {
-				// Down-pointing triangle (region is expanded, click to collapse)
-				int[] pts = { cx - s, cy - (s - 3), cx + s, cy - (s - 3), cx, cy + (s - 1) };
-				gc.fillPolygon(pts);
+				// Triangles (default shape).
+				int s = 6;
+				if (isFolded) {
+					// Right-pointing triangle (region is collapsed)
+					int[] pts = { cx - (s - 2), cy - s, cx + (s - 1), cy, cx - (s - 2), cy + s };
+					gc.fillPolygon(pts);
+				} else {
+					// Down-pointing triangle (region is expanded, click to collapse)
+					int[] pts = { cx - s, cy - (s - 3), cx + s, cy - (s - 3), cx, cy + (s - 1) };
+					gc.fillPolygon(pts);
+				}
 			}
 		}
 		gc.setForeground(oldFg);
@@ -979,6 +1102,12 @@ public class FoldingManager implements HiddenTextProvider {
 	}
 
 	public void dispose() {
+		if (!txt.isDisposed()) {
+			if (modifyListener != null) txt.removeExtendedModifyListener(modifyListener);
+			if (paintListener != null) txt.removePaintListener(paintListener);
+			if (mouseListener != null) txt.removeMouseListener(mouseListener);
+		}
 		if (markerColor != null && !markerColor.isDisposed()) markerColor.dispose();
+		if (guideColor != null && !guideColor.isDisposed()) guideColor.dispose();
 	}
 }

--- a/com/repdev/MainShell.java
+++ b/com/repdev/MainShell.java
@@ -4027,6 +4027,37 @@ public class MainShell {
 		return mainfolder;
 	}
 
+	/**
+	 * Tear down code folding on every open editor. Called when the user disables the
+	 * "Enable code folding" option so open tabs unfold and lose their fold gutter
+	 * immediately, rather than staying folded until reopened.
+	 */
+	public void disableFoldingOnOpenEditors() {
+		if (mainfolder == null || mainfolder.isDisposed())
+			return;
+		for (CTabItem tab : mainfolder.getItems()) {
+			if (tab.getControl() instanceof EditorComposite)
+				((EditorComposite) tab.getControl()).disableFolding();
+		}
+	}
+
+	/**
+	 * Re-read theme-derived colors for every open editor. Called after a style change
+	 * so the fold-triangle color (and any repaint-driven syntax colors) update live,
+	 * without needing to reopen tabs.
+	 */
+	public void refreshEditorStyles() {
+		if (mainfolder == null || mainfolder.isDisposed())
+			return;
+		for (CTabItem tab : mainfolder.getItems()) {
+			if (tab.getControl() instanceof EditorComposite) {
+				FoldingManager fm = ((EditorComposite) tab.getControl()).getFolding();
+				if (fm != null)
+					fm.refreshStyle();
+			}
+		}
+	}
+
 	private void setMainTitle(){
 		String server = "";
 		int sym;

--- a/com/repdev/MainShell.java
+++ b/com/repdev/MainShell.java
@@ -31,13 +31,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Stack;
 
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
-import org.eclipse.swt.custom.CTabFolder2Adapter;
-import org.eclipse.swt.custom.CTabFolderEvent;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.custom.StyledTextPrintOptions;
@@ -70,7 +65,6 @@ import org.eclipse.swt.events.ShellAdapter;
 import org.eclipse.swt.events.ShellEvent;
 //import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Color;
-import org.eclipse.swt.graphics.Cursor;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
@@ -110,11 +104,8 @@ import org.eclipse.swt.widgets.ToolBar;
 import org.eclipse.swt.widgets.ToolItem;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
-import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 import com.repdev.parser.Error;
 import com.repdev.parser.RepgenParser;
@@ -122,7 +113,6 @@ import com.repdev.parser.Task;
 
 // no longer supported in modern java versions, Boolean is provide by jdk
 //import com.sun.org.apache.xpath.internal.operations.Bool;
-//import com.sun.xml.internal.ws.util.xml.NodeListIterator;
 
 /**
  * Main graphical user interface. Provides some utility methods as well. Really
@@ -136,12 +126,12 @@ import com.repdev.parser.Task;
 
 public class MainShell {
 	private static final int MIN_COL_WIDTH = 75, MIN_COMP_SIZE = 65;
-	private CTabFolder mainfolder;
-	private Display display;
+	private EditorPaneManager panes;
+	Display display;
 	//private Shell shell;
 	private Tree tree;
 	private Table tblErrors, tblTasks;
-	private FindReplaceShell findReplaceShell;
+	FindReplaceShell findReplaceShell;
 	private SurroundWithShell surroundWithShell;
 	private final int MAX_RECENTS = 5;
 	private ArrayList<CTabItem> tabHistory = new ArrayList<CTabItem>();
@@ -151,7 +141,8 @@ public class MainShell {
 	// CoolBar for our universal tool bar at the top.
 	private CoolBar coolBar;
 	private ToolBar editorBar;
-	private ToolItem savetb, install, print, run, hltoggle, fscreen;
+	ToolItem savetb, install, print, run, hltoggle;
+	private ToolItem fscreen;
 	private ArrayList<CoolItem> coolItems; // <-- may not be needed, keep for
 	// future stuff though
 
@@ -205,7 +196,7 @@ public class MainShell {
 				}
 				Config.setWindowSize(shell.getSize());
 
-				for (CTabItem tab : mainfolder.getItems())
+				for (CTabItem tab : panes.allItems())
 					if (!confirmClose(tab))
 						close = false;
 
@@ -377,67 +368,59 @@ public class MainShell {
 	}
 
 	public Object openFile(Sequence seq, int sym) {
-		boolean found = false;
 		Composite editor;
 
-		for (CTabItem c : mainfolder.getItems()) {
-			if (c.getData("seq") != null && (Sequence) c.getData("seq") == seq && c.getData("sym") != null && ((Integer) c.getData("sym")) == sym) {
-				setMainFolderSelection(c);
-				found = true;
-				return c.getControl();
+		CTabItem existing = panes.findItem(seq, sym);
+		if (existing != null) {
+			setMainFolderSelection(existing);
+			return existing.getControl();
+		}
+
+		CTabItem item = panes.newItem(SWT.CLOSE);
+
+		item.setText("Sequence View: " + seq.getSeq());
+		// item.setToolTipText("Sequence View: " + seq.getSeq()); // only enable this if we are shrinking tabs
+
+		item.setData("seq", seq);
+		item.setData("sym", sym);
+
+		item.setImage(drawSymOverImage(RepDevMain.smallReportsImage, sym));
+
+		editor = new ReportComposite(item.getParent(), item, seq);
+		editor.addFocusListener(new FocusListener() {
+			public void focusGained(FocusEvent e) {
+
 			}
-		}
 
-		if (!found) {
-			CTabItem item = new CTabItem(mainfolder, SWT.CLOSE);
+			public void focusLost(FocusEvent e) {
 
-			item.setText("Sequence View: " + seq.getSeq());
-			// item.setToolTipText("Sequence View: " + seq.getSeq()); // only enable this if we are shrinking tabs
+			}
+		});
 
-			item.setData("seq", seq);
-			item.setData("sym", sym);
+		run.setEnabled(false);
+		savetb.setEnabled(false);
+		install.setEnabled(false);
+		hltoggle.setEnabled(false);
 
-			item.setImage(drawSymOverImage(RepDevMain.smallReportsImage, sym));
+		// If anything goes wrong initializing the error, it will dispose of
+		// the current item
+		// So, then we shouldn't do anything
+		if (item.isDisposed())
+			return null;
 
-			editor = new ReportComposite(mainfolder, item, seq);
-			editor.addFocusListener(new FocusListener() {
-				public void focusGained(FocusEvent e) {
+		//activeFolder().setSelection(item);
+		setMainFolderSelection(item);
+		item.setControl(editor);
 
-				}
+		// Attach find/replace shell here as well (in addition to folder
+		// listener)
+		findReplaceShell.attach(((ReportComposite) editor).getStyledText(), false);
+		setMainTitle();
 
-				public void focusLost(FocusEvent e) {
-
-				}
-			});
-
-			run.setEnabled(false);
-			savetb.setEnabled(false);
-			install.setEnabled(false);
-			hltoggle.setEnabled(false);
-
-			// If anything goes wrong initializing the error, it will dispose of
-			// the current item
-			// So, then we shouldn't do anything
-			if (item.isDisposed())
-				return null;
-
-			//mainfolder.setSelection(item);
-			setMainFolderSelection(item);
-			item.setControl(editor);
-
-			// Attach find/replace shell here as well (in addition to folder
-			// listener)
-			findReplaceShell.attach(((ReportComposite) editor).getStyledText(), false);
-			setMainTitle();
-
-			return editor;
-		}
-
-		return null;
+		return editor;
 	}
 
 	public Object openFile(final SymitarFile file) {
-		boolean found = false;
 		Composite editor;
 		Object loc;
 
@@ -446,99 +429,92 @@ public class MainShell {
 		else
 			loc = file.getSym();
 
-		for (CTabItem c : mainfolder.getItems()) {
-			if (c.getData("file") != null && c.getData("file").equals(file) && c.getData("loc") != null && c.getData("loc").equals(loc)) {
-				setMainFolderSelection(c);
-				found = true;
-				return c.getControl();
-			}
+		CTabItem existing = panes.findItem(file, loc);
+		if (existing != null) {
+			setMainFolderSelection(existing);
+			return existing.getControl();
 		}
 
-		if (!found) {
-			CTabItem item = new CTabItem(mainfolder, SWT.CLOSE); 
-			item.setText(file.getName());
-			// item.setToolTipText(file.getName()); // only use this if we are shrinking tabs
-			item.setImage(getFileImage(file));
-			item.setData("file", file);
-			item.setData("loc", loc);
+		CTabItem item = panes.newItem(SWT.CLOSE);
+		item.setText(file.getName());
+		// item.setToolTipText(file.getName()); // only use this if we are shrinking tabs
+		item.setImage(getFileImage(file));
+		item.setData("file", file);
+		item.setData("loc", loc);
 
-			if (file.getType() == FileType.REPORT)
-				editor = new ReportComposite(mainfolder, item, file);
-			else {
-				editor = new EditorComposite(mainfolder, item, file /*
-				 * ,save,
-				 * install,
-				 * print,
-				 * run
-				 */);
-				//EditorCompositeList.add((EditorComposite)editor);
-			}
+		if (file.getType() == FileType.REPORT)
+			editor = new ReportComposite(item.getParent(), item, file);
+		else {
+			editor = new EditorComposite(item.getParent(), item, file /*
+			 * ,save,
+			 * install,
+			 * print,
+			 * run
+			 */);
+			//EditorCompositeList.add((EditorComposite)editor);
+		}
 
-			// If anything goes wrong creating the Editor, we want to fail here
-			// It will dispose of the item to indicate this fault.
-			if (file.isCompareMode()) {
-				file.compareMode(false);
+		// If anything goes wrong creating the Editor, we want to fail here
+		// It will dispose of the item to indicate this fault.
+		if (file.isCompareMode()) {
+			file.compareMode(false);
+			return null;
+		} else {
+			if (item.isDisposed()) {
+				MessageBox dialog = new MessageBox(shell, SWT.ICON_ERROR | SWT.OK);
+				dialog.setMessage("There has been an error loading this file, the filename is probably too long");
+				dialog.setText("Error");
+				dialog.open();
+
 				return null;
-			} else {
-				if (item.isDisposed()) {
-					MessageBox dialog = new MessageBox(shell, SWT.ICON_ERROR | SWT.OK);
-					dialog.setMessage("There has been an error loading this file, the filename is probably too long");
-					dialog.setText("Error");
-					dialog.open();
-
-					return null;
-				}
 			}
-			mainfolder.setSelection(item);
-			item.setControl(editor);
-			setMainFolderSelection(item);
-			mainfolder.notifyListeners(SWT.Selection, new Event());
-			
-
-
-			//When we are closing, we must dispose the control in the CTabItem, otherwise we leak swt objects
-			item.addDisposeListener(new DisposeListener(){
-				public void widgetDisposed(DisposeEvent e) {
-					if(((CTabItem)e.widget).getControl() != null)
-						((CTabItem)e.widget).getControl().dispose();
-				}
-			});
-
-			if (file.getType() != FileType.REPGEN || file.isLocal())
-				install.setEnabled(false);
-			else
-				install.setEnabled(true);
-
-			if (file.getType() != FileType.REPGEN || file.isLocal())
-				run.setEnabled(false);
-			else
-				run.setEnabled(true);
-
-			savetb.setEnabled(true);
-
-			if ((file.getType() == FileType.REPGEN)||(file.getType() == FileType.LETTER)||(file.getType() == FileType.HELP)||(file.getType() == FileType.DATA))
-				hltoggle.setEnabled(true);
-
-			if (mainfolder.getSelection().getControl() instanceof EditorComposite){
-				if(((EditorComposite)mainfolder.getSelection().getControl()).getHighlight()){
-					hltoggle.setImage(RepDevMain.smallHighlight);
-				}else{
-					hltoggle.setImage(RepDevMain.smallHighlightGrey);
-				}
-			}
-			// Attach find/replace shell here as well (in addition to folder
-			// listener)
-			findReplaceShell.attach(((EditorComposite) mainfolder.getSelection().getControl()).getStyledText(), true);
-
-			if (!Config.getRecentFiles().contains(file))
-				Config.getRecentFiles().add(0, file);
-
-			if (Config.getRecentFiles().size() > MAX_RECENTS)
-				Config.getRecentFiles().remove(Config.getRecentFiles().size() - 1);
-			return editor;
 		}
+		item.setControl(editor);
+		setMainFolderSelection(item);
+		item.getParent().notifyListeners(SWT.Selection, new Event());
 
-		return null;
+
+
+		//When we are closing, we must dispose the control in the CTabItem, otherwise we leak swt objects
+		item.addDisposeListener(new DisposeListener(){
+			public void widgetDisposed(DisposeEvent e) {
+				if(((CTabItem)e.widget).getControl() != null)
+					((CTabItem)e.widget).getControl().dispose();
+			}
+		});
+
+		if (file.getType() != FileType.REPGEN || file.isLocal())
+			install.setEnabled(false);
+		else
+			install.setEnabled(true);
+
+		if (file.getType() != FileType.REPGEN || file.isLocal())
+			run.setEnabled(false);
+		else
+			run.setEnabled(true);
+
+		savetb.setEnabled(true);
+
+		if ((file.getType() == FileType.REPGEN)||(file.getType() == FileType.LETTER)||(file.getType() == FileType.HELP)||(file.getType() == FileType.DATA))
+			hltoggle.setEnabled(true);
+
+		if (activeFolder().getSelection().getControl() instanceof EditorComposite){
+			if(((EditorComposite)activeFolder().getSelection().getControl()).getHighlight()){
+				hltoggle.setImage(RepDevMain.smallHighlight);
+			}else{
+				hltoggle.setImage(RepDevMain.smallHighlightGrey);
+			}
+		}
+		// Attach find/replace shell here as well (in addition to folder
+		// listener)
+		findReplaceShell.attach(((EditorComposite) activeFolder().getSelection().getControl()).getStyledText(), true);
+
+		if (!Config.getRecentFiles().contains(file))
+			Config.getRecentFiles().add(0, file);
+
+		if (Config.getRecentFiles().size() > MAX_RECENTS)
+			Config.getRecentFiles().remove(Config.getRecentFiles().size() - 1);
+		return editor;
 	}
 
 	private void doubleClickTreeItem() {
@@ -851,7 +827,7 @@ public class MainShell {
 			ProjectManager.saveProjects(proj.getDir());
 
 		tree.notifyListeners(SWT.Selection, null);
-		for (CTabItem c : mainfolder.getItems()) {
+		for (CTabItem c : panes.allItems()) {
 			if (c.getData("file") != null && c.getData("file").equals(file)) {
 				c.dispose();
 			}
@@ -1513,7 +1489,7 @@ public class MainShell {
 
 				// Go thru the Tab Items to see if the RepGen is currently open.  If it is,
 				// Then install it.
-				for(CTabItem tf : mainfolder.getItems()){
+				for(CTabItem tf : panes.allItems()){
 					// Run only if the RepGen is found.
 					try{
 						if(tf.getControl() instanceof EditorComposite &&
@@ -1528,11 +1504,11 @@ public class MainShell {
 							setMainFolderSelection(tf);
 							if(modified == true){
 								// If the RepGen was modified, prompt to save and install
-								((EditorComposite) mainfolder.getSelection().getControl()).installRepgen(true);
+								((EditorComposite) activeFolder().getSelection().getControl()).installRepgen(true);
 							}
 							else{
 								// If the RepGen was not modified, install
-								((EditorComposite) mainfolder.getSelection().getControl()).installRepgen(false);
+								((EditorComposite) activeFolder().getSelection().getControl()).installRepgen(false);
 							}
 						}
 					}
@@ -1770,13 +1746,13 @@ public class MainShell {
 
 				if (dialog.open() == SWT.OK) {
 					/*
-					 * if( mainfolder.getSelectionIndex() != -1){ if(
-					 * confirmClose(mainfolder.getSelection()) ){
-					 * clearErrorList(mainfolder.getSelection());
-					 * mainfolder.getSelection().dispose(); setLineColumn(); } }
+					 * if( activeFolder().getSelectionIndex() != -1){ if(
+					 * confirmClose(activeFolder().getSelection()) ){
+					 * clearErrorList(activeFolder().getSelection());
+					 * activeFolder().getSelection().dispose(); setLineColumn(); } }
 					 */
 
-					for (CTabItem item : mainfolder.getItems()) {
+					for (CTabItem item : panes.allItems()) {
 						if ( item.getData("file") != null && (((SymitarFile) item.getData("file")).getSym() == sym) && confirmClose(item)) {
 							clearErrorAndTaskList(item);
 							item.dispose();
@@ -2112,7 +2088,7 @@ public class MainShell {
 				item.setText(newName); // Set name in tree
 
 				// Now, set name in any open tabs
-				for (CTabItem c : mainfolder.getItems()) {
+				for (CTabItem c : panes.allItems()) {
 					if (c.getData("file") == item.getData()) // Be sure it's the
 						// exact same
 						// instance, like it
@@ -2276,9 +2252,9 @@ public class MainShell {
 		//this, but for the time being it should work.
 		
 		/*EditorComposite temp = (EditorComposite)openFile(f1);
-		for (CTabItem tab : mainfolder.getItems()){
+		for (CTabItem tab : panes.allItems()){
 			if (tab.getControl() != null && tab.getControl() instanceof EditorComposite){
-				bgcolor =((EditorComposite)mainfolder.getSelection().getControl()).getLineColor();
+				bgcolor =((EditorComposite)activeFolder().getSelection().getControl()).getLineColor();
 			}
 			if (tab.getControl() != null && tab.getControl() instanceof EditorComposite && tab.getControl() == temp){
 				tab.dispose();
@@ -2289,7 +2265,7 @@ public class MainShell {
 		//TODO:Rewrite the above section so that it runs faster, or determines the color in another way
 
 
-		CTabItem item = new CTabItem(mainfolder, SWT.CLOSE);
+		CTabItem item = panes.newItem(SWT.CLOSE);
 
 		item.setText("Compare Text BETA");
 		item.setImage(RepDevMain.smallCompareImage);
@@ -2297,7 +2273,7 @@ public class MainShell {
 		// item.setData("file", file);
 		// item.setData("loc", loc);
 
-		item.setControl(new CompareComposite(mainfolder, item, f1, f2, bgcolor));
+		item.setControl(new CompareComposite(item.getParent(), item, f1, f2, bgcolor));
 
 		item.addDisposeListener(new DisposeListener(){
 
@@ -2376,8 +2352,8 @@ public class MainShell {
 	public void setLineColumn() {
 		int line, col;
 
-		if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof TabTextView) {
-			StyledText txt = ((TabTextView) mainfolder.getSelection().getControl()).getStyledText();
+		if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof TabTextView) {
+			StyledText txt = ((TabTextView) activeFolder().getSelection().getControl()).getStyledText();
 			line = txt.getLineAtOffset(txt.getCaretOffset());
 			col = txt.getCaretOffset() - txt.getOffsetAtLine(line) + 1;
 
@@ -2535,17 +2511,19 @@ public class MainShell {
 	// Draw Rectangle Around Destination Tab Start
 	PaintListener destTabRectPL;
 	Rectangle destTabRect = new Rectangle(0, 0, 0, 0);
-	private void drawDestTabRect(CTabItem destTab){
+	CTabFolder destTabRectFolder;
+	void drawDestTabRect(CTabItem destTab){
 		if(destTab != null){
-			if(destTabRect.x != destTab.getBounds().x){ // Only do this if new or we are in a new tab spot
+			if(destTabRectFolder != destTab.getParent() || destTabRect.x != destTab.getBounds().x){ // Only do this if new or we are in a new tab spot
 				
-				if(destTabRectPL != null){ // dragging over new tab spot - remove old if exists
-					mainfolder.removePaintListener(destTabRectPL);
+				if(destTabRectPL != null && destTabRectFolder != null && !destTabRectFolder.isDisposed()){ // dragging over new tab spot - remove old if exists
+					destTabRectFolder.removePaintListener(destTabRectPL);
 					//destTabRect = null;
 					//destTabRectPL = null;
 				}
 				
 				destTabRect = destTab.getBounds();
+				destTabRectFolder = destTab.getParent();
 				destTabRectPL = new PaintListener()
 				{
 			        public void paintControl(PaintEvent e) {
@@ -2555,13 +2533,14 @@ public class MainShell {
 			            e.gc.drawRectangle(destTabRect);
 			        }
 			    };
-				mainfolder.addPaintListener(destTabRectPL);
-				mainfolder.redraw();
+				destTabRectFolder.addPaintListener(destTabRectPL);
+				destTabRectFolder.redraw();
 			}
 		}
 		else{
-			if(destTabRectPL != null)
-				mainfolder.removePaintListener(destTabRectPL); // Null destTab Argument means remove the rectangle
+			if(destTabRectPL != null && destTabRectFolder != null && !destTabRectFolder.isDisposed())
+				destTabRectFolder.removePaintListener(destTabRectPL); // Null destTab Argument means remove the rectangle
+			destTabRectFolder = null;
 			}
 		
 	}
@@ -2583,365 +2562,38 @@ public class MainShell {
 	Color titleForeColor = null, titleBackColor1 = null, titleBackColor2 = null;
 	private void createEditorPane(Composite self) {
 		self.setLayout(new FillLayout());
-		mainfolder = new CTabFolder(self,  SWT.TOP | SWT.BORDER);
-		final Cursor cursor = new Cursor(display, SWT.CURSOR_SIZEALL);
-		mainfolder.setLayout(new FillLayout());
-		mainfolder.setSimple(false);
+		panes = new EditorPaneManager(self, this);
+	}
 
-		Menu tabContextMenu = new Menu(mainfolder);
-		mainfolder.setMenu(tabContextMenu);
+	/**
+	 * The editor folder the user is currently working in. Most of MainShell's tab code
+	 * means exactly "the folder holding the tab in front of me" and is correct
+	 * unchanged once it resolves through here. Call sites that instead mean "every open
+	 * tab" meed to use panes.allItems();
+	 */
+	private CTabFolder activeFolder() {
+		return panes.active();
+	}
 
-		// XP Theme Color Tabs With Gradient start
-		  try {
-				  File file = new File("styles\\" + Config.getStyle() + ".xml");
-				  DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-				  DocumentBuilder db = dbf.newDocumentBuilder();
-				  Document doc = db.parse(file);
-				  doc.getDocumentElement().normalize();
-				  NodeList nodeLst = doc.getElementsByTagName("tabStyle");
-				  if(nodeLst.getLength() > 0){
-					  NamedNodeMap attributes = nodeLst.item(0).getAttributes();
-					  titleForeColor = HextoColor(attributes.getNamedItem("fgColor").getTextContent());
-					  titleBackColor1 = HextoColor(attributes.getNamedItem("bgcolor1").getTextContent());
-					  titleBackColor2 = HextoColor(attributes.getNamedItem("bgcolor2").getTextContent());
-				  }
-			  } catch (Exception e) {
-				  e.printStackTrace();
-			  }
-			  if(titleForeColor == null || titleBackColor1 == null || titleBackColor2 == null){
-				titleForeColor = display.getSystemColor(SWT.COLOR_TITLE_FOREGROUND);
-				titleBackColor1 = display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND);
-				titleBackColor2 = display.getSystemColor(SWT.COLOR_TITLE_BACKGROUND_GRADIENT);
-			  }
-		mainfolder.setSelectionForeground(titleForeColor);
-		mainfolder.setSelectionBackground(new Color[] { titleBackColor1,titleBackColor2 }, new int[] { 100 }, true);
-		//  XP Theme Color Tabs With Gradient End
-		
-		// Drag tab code start
-		// Close tab with middle mouse code start
-		// Tab history code start
-		Listener listener = new Listener() {
-			boolean drag = false;
-			boolean exitDrag = false;
-			CTabItem dragItem;
-			public void handleEvent(Event e) {
-				Point p = new Point(e.x, e.y);
-				if (e.type == SWT.DragDetect) {
-					p = mainfolder.toControl(display.getCursorLocation()); // see bug 43251
-				}
-				switch (e.type) {
-				case SWT.MouseDown: {
-					  if (e.button == 2){ // Close tab with middle click (or mouse wheel click)
-							if (confirmClose(mainfolder.getSelection())) {
-								clearErrorAndTaskList(mainfolder.getSelection());
-								mainfolder.getSelection().dispose();
-								setLineColumn();
-							}
-					  }
-					  else{ // Record that tab selection was changed
-						  addToTabHistory();
-						  //addToNavHistory(((EditorComposite)item.getControl()).getFile(),line);
-					  }
-					  break;
-				}
-				case SWT.DragDetect: {
-					CTabItem item = mainfolder.getItem(p);
-					if (item == null)
-						return;
-					//e.image = display.getSystemImage(SWT.ICON_WARNING);
+	EditorPaneManager getPanes() {
+		return panes;
+	}
 
-					drag = true;
-					exitDrag = false;
-					dragItem = item;
-					mainfolder.setCursor(cursor);
-					break;
-				}
-				case SWT.MouseEnter:
-					if (exitDrag) {
-						exitDrag = false;
-						drag = e.button != 0;
-					}
-					break;
-				case SWT.MouseExit:
-					if (drag) {
-						mainfolder.setInsertMark(null, false);
-						exitDrag = true;
-						drag = false;
-					}
-					break;
-				case SWT.MouseUp: {
-					if (!drag)
-						return;
-					mainfolder.setInsertMark(null, false);
-					drawDestTabRect(null);
-					CTabItem item = mainfolder.getItem(new Point(p.x, 1));
-					if (item != null) {
-						Rectangle sourceRect = dragItem.getBounds();
-						Rectangle destRect = item.getBounds();
-						boolean after = sourceRect.x < destRect.x;
-						int index = mainfolder.indexOf(item);
-						index = after ? index + 1 : index - 0;
-						index = Math.max(0, index);
-						CTabItem newItem = new CTabItem(mainfolder, SWT.CLOSE, index);
-						//newItem.setText("new tab item");
-						newItem.setText(dragItem.getText()); // move over the tab's text
-						newItem.setToolTipText(newItem.getToolTipText()); // move over tooltip text
-						
-						newItem.setImage(dragItem.getImage()); // Mover over the sym icon
-						Control c = dragItem.getControl();
-						
-						newItem.setControl(c);
-						// move over data attributes for files and reports
-						if(dragItem.getData("seq") != null)
-							newItem.setData("seq", dragItem.getData("seq"));
-						if(dragItem.getData("sym") != null)
-							newItem.setData("sym", dragItem.getData("sym"));
-						if(dragItem.getData("file") != null)
-							newItem.setData("file", dragItem.getData("file"));
-						if(dragItem.getData("loc") != null)
-							newItem.setData("loc", dragItem.getData("loc"));
-						if(dragItem.getData("modified") != null)
-							newItem.setData("modified", dragItem.getData("modified"));
-						if(dragItem.getData("error") != null)
-							newItem.setData("error", dragItem.getData("error"));
-						if(dragItem.getData("task") != null)
-							newItem.setData("task", dragItem.getData("task"));
-						dragItem.setControl(null);
-						dragItem.dispose();
-						setMainFolderSelection(newItem);
-						if (mainfolder.getSelection() != null && (mainfolder.getSelection().getControl()) instanceof EditorComposite)
-							((EditorComposite) mainfolder.getSelection().getControl()).getStyledText().setFocus();
-						setMainTitle();
-					}
-					drag = false;
-					exitDrag = false;
-					dragItem = null;
-					mainfolder.setCursor(null);
-					break;
-				}
-				case SWT.MouseMove: {
-					if (!drag)
-						return;
-					CTabItem item = mainfolder.getItem(new Point(p.x, 2));
-					if (item == null) {
-						mainfolder.setInsertMark(null, false);
-						drawDestTabRect(null);
-						return;
-					}
-					Rectangle rect = item.getBounds();
-					boolean after = p.x > rect.x + rect.width / 2;
-					mainfolder.setInsertMark(item, after);
-					drawDestTabRect(item);
-//				    // Workaround for bug #32846
-//				    if (item == -1) {
-//				    	mainfolder.redraw();
-//				    }
-					break;
-				}
-				}
-			}
-		};
-		mainfolder.addListener(SWT.DragDetect, listener);
-		mainfolder.addListener(SWT.MouseUp, listener);
-		mainfolder.addListener(SWT.MouseMove, listener);
-		mainfolder.addListener(SWT.MouseExit, listener);
-		mainfolder.addListener(SWT.MouseEnter, listener);
-		mainfolder.addListener(SWT.MouseDown, listener);
+	void splitEditorHere() {
+		CTabItem sel = panes.active().getSelection();
+		if (sel != null)
+			panes.moveToOtherView(sel);
+	}
 
-		// Drag tab code end
+	void toggleSplitOrientation() {
+		if (!panes.isSplit())
+			return;
+		panes.setOrientation(panes.getOrientation() == SWT.HORIZONTAL ? SWT.VERTICAL : SWT.HORIZONTAL);
+		Config.setSplitOrientation(panes.getOrientation());
+	}
 
-		mainfolder.addSelectionListener(new SelectionAdapter() {
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelection() != null && (mainfolder.getSelection().getControl()) instanceof EditorComposite) {
-					SymitarFile file = ((EditorComposite) mainfolder.getSelection().getControl()).getFile();
-					if (file.getType() != FileType.REPGEN || file.isLocal())
-						install.setEnabled(false);
-					else
-						install.setEnabled(true);
-
-					if (file.getType() != FileType.REPGEN || file.isLocal())
-						run.setEnabled(false);
-					else
-						run.setEnabled(true);
-
-					if ((file.getType() == FileType.REPGEN)||(file.getType() == FileType.LETTER)||(file.getType() == FileType.HELP)||(file.getType() == FileType.DATA))
-						hltoggle.setEnabled(true);
-
-					savetb.setEnabled(true);
-					print.setEnabled(true);
-				} else {
-					print.setEnabled(true);
-					savetb.setEnabled(false);
-					run.setEnabled(false);
-					install.setEnabled(false);
-					hltoggle.setEnabled(false);
-				}
-			}
-		});
-
-		final MenuItem closeTab = new MenuItem(tabContextMenu, SWT.NONE);
-		closeTab.setText("Close Tab");
-		closeTab.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelectionIndex() != -1) {
-					if (confirmClose(mainfolder.getSelection())) {
-						clearErrorAndTaskList(mainfolder.getSelection());
-						mainfolder.getSelection().dispose();
-						setLineColumn();
-					}
-				}
-			}
-
-		});
-
-		final MenuItem closeOthers = new MenuItem(tabContextMenu, SWT.NONE);
-		closeOthers.setText("Close Others");
-		closeOthers.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getItems().length > 1) {
-
-					for (CTabItem item : mainfolder.getItems())
-						if (!item.equals(mainfolder.getSelection()))
-							if (confirmClose(item)) {
-								clearErrorAndTaskList(item);
-								item.dispose();
-							}
-
-				}
-			}
-
-		});
-
-		final MenuItem closeAll = new MenuItem(tabContextMenu, SWT.NONE);
-		closeAll.setText("Close All");
-		closeAll.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getItems().length >= 1) {
-
-					for (CTabItem item : mainfolder.getItems())
-						if (confirmClose(item)) {
-							clearErrorAndTaskList(item);
-							item.dispose();
-						}
-
-				}
-			}
-
-		});
-
-		final MenuItem separator = new MenuItem(tabContextMenu, SWT.SEPARATOR);
-
-		final MenuItem save = new MenuItem(tabContextMenu, SWT.None);
-		save.setText("Save");
-		save.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelectionIndex() != -1 && (mainfolder.getSelection().getControl() instanceof EditorComposite)) {
-					((EditorComposite) mainfolder.getSelection().getControl()).saveFile(true);
-				} else {
-					System.out.println("Error:  Can not save non-EditorComposite File");
-				}
-			}
-		});
-
-		final MenuItem saveAll = new MenuItem(tabContextMenu, SWT.NONE);
-		saveAll.setText("Save All");
-		saveAll.addSelectionListener(new SelectionAdapter() {
-
-			@Override
-			public void widgetSelected(SelectionEvent e) {
-				saveAllRepgens();
-			}
-
-		});
-
-		final MenuItem installRepgen = new MenuItem(tabContextMenu, SWT.NONE);
-		installRepgen.setText("Install");
-		installRepgen.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelectionIndex() != -1 && (mainfolder.getSelection().getControl() instanceof EditorComposite)) {
-
-					((EditorComposite) mainfolder.getSelection().getControl()).installRepgen(true);
-				}
-			}
-		});
-
-		tabContextMenu.addMenuListener(new MenuAdapter() {
-
-			@Override
-			public void menuShown(MenuEvent e) {
-				boolean flag = mainfolder.getSelectionIndex() != -1;
-
-				closeTab.setEnabled(flag);
-				closeAll.setEnabled(flag);
-
-				save
-				.setEnabled((flag && (mainfolder.getSelection().getControl() instanceof EditorComposite) && mainfolder.getSelection().getData("modified") != null && (Boolean) mainfolder
-						.getSelection().getData("modified")));
-
-				saveAll.setEnabled(flag);
-				installRepgen.setEnabled(flag && (mainfolder.getSelection().getControl() instanceof EditorComposite)
-						&& !((EditorComposite) mainfolder.getSelection().getControl()).getFile().isLocal());
-
-				closeOthers.setEnabled(mainfolder.getItems().length > 1);
-
-			}
-
-		});
-
-		// Make the find/replace box know which thing we are looking through, if
-		// the window is open as we switch tabs
-		mainfolder.addSelectionListener(new SelectionAdapter() {
-			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite)
-					findReplaceShell.attach(((EditorComposite) mainfolder.getSelection().getControl()).getStyledText(), true);
-				else if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof ReportComposite)
-					findReplaceShell.attach(((ReportComposite) mainfolder.getSelection().getControl()).getStyledText(), false);
-				
-				// show active repgen's title in the window title
-				setMainTitle();
-			}
-
-		});
-
-		mainfolder.addSelectionListener(new SelectionAdapter(){
-			public void widgetSelected(SelectionEvent e){
-				if (mainfolder.getSelection().getControl() instanceof EditorComposite){
-					if(((EditorComposite)mainfolder.getSelection().getControl()).getHighlight()){
-						hltoggle.setImage(RepDevMain.smallHighlight);
-					}else{
-						hltoggle.setImage(RepDevMain.smallHighlightGrey);
-					}
-				}
-			}
-		});
-
-		mainfolder.addCTabFolder2Listener(new CTabFolder2Adapter() {
-			public void close(CTabFolderEvent event) {
-				event.doit = confirmClose((CTabItem) event.item);
-				setLineColumn();
-
-				if (event.doit) {
-					if( mainfolder.getSelection() == event.item )
-						shell.setText(RepDevMain.NAMESTR); // remove active repgen name from title
-					clearErrorAndTaskList((CTabItem) event.item);
-				}
-
-				if (mainfolder.getItemCount() == 1) {
-					install.setEnabled(false);
-					savetb.setEnabled(false);
-					hltoggle.setEnabled(false);
-					print.setEnabled(false);
-					run.setEnabled(false);
-				}
-			}
-		});
+	void focusOtherEditorView() {
+		panes.focusOtherView();
 	}
 
 	protected void clearErrorAndTaskList(CTabItem item) {
@@ -2970,7 +2622,22 @@ public class MainShell {
 		}
 	}
 
-	private boolean confirmClose(CTabItem item) {
+	/**
+	 * Copies presentation and data attributes from one tab to another. Used both by
+	 * in-folder tab dragging and by moves between editor panes. Deliberately does not
+	 * touch setControl.. the caller owns control ownership and disposal ordering.
+	 */
+	static void copyTabState(CTabItem from, CTabItem to) {
+		to.setText(from.getText());
+		to.setToolTipText(from.getToolTipText());
+		to.setImage(from.getImage());
+
+		for (String key : new String[] { "seq", "sym", "file", "loc", "modified", "error", "task" })
+			if (from.getData(key) != null)
+				to.setData(key, from.getData(key));
+	}
+
+	boolean confirmClose(CTabItem item) {
 		if (item != null && item.getData("modified") != null && ((Boolean) item.getData("modified"))) {
 			MessageBox dialog = new MessageBox(shell, SWT.ICON_QUESTION | SWT.YES | SWT.NO | SWT.CANCEL);
 			dialog.setText("Confirm File Close");
@@ -2989,12 +2656,11 @@ public class MainShell {
 			}
 		}
 
-		if (mainfolder.getSelection().getControl() instanceof EditorComposite)
+		if (item.getControl() instanceof EditorComposite)
 			for (TableItem tItem : tblErrors.getItems())
-				if (tItem.getData("file").equals(mainfolder.getSelection().getData("file")) && tItem.getData("sym").equals(mainfolder.getSelection().getData("sym"))){
+				if (tItem.getData("file").equals(item.getData("file"))
+						&& tItem.getData("sym").equals(item.getData("sym")))
 					tItem.dispose();
-					//EditorCompositeList.remove(mainfolder.getSelection().getControl());
-				}
 		// Remove entries matching this tab from the tabHistory stack since we are closing the file
 		List<CTabItem> closingTab = Arrays.asList(item);
 		tabHistory.removeAll(closingTab);
@@ -3177,8 +2843,10 @@ public class MainShell {
 	}
 			
 		
-	private void setMainFolderSelection(CTabItem item){
-		mainfolder.setSelection(item);
+	void setMainFolderSelection(CTabItem item){
+		if (item == null)
+			return;
+		item.getParent().setSelection(item);
 		addToTabHistory();
 
 			//RepgenParser parser = ((EditorComposite)cur.getControl()).getParser();
@@ -3186,20 +2854,20 @@ public class MainShell {
 	}
 	public void addToTabHistory()
 	{
-		if(mainfolder.getSelectionIndex() == -1 || !(mainfolder.getItem(mainfolder.getSelectionIndex()) instanceof TabTextView))
+		if(activeFolder().getSelectionIndex() == -1 || !(activeFolder().getItem(activeFolder().getSelectionIndex()) instanceof TabTextView))
 			return; // There is no index... return or we will crash with array out of bounds
-		  if( tabHistory.isEmpty() || !tabHistory.get(tabHistory.size()-1).equals(mainfolder.getSelection())){
-			  tabHistory.add(mainfolder.getSelection());
+		  if( tabHistory.isEmpty() || !tabHistory.get(tabHistory.size()-1).equals(activeFolder().getSelection())){
+			  tabHistory.add(activeFolder().getSelection());
 			  // the following used to reside in setMainFolderSelection
-				if(((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()) != null){
-					StyledText txt = ((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText();
+				if(((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()) != null){
+					StyledText txt = ((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText();
 					int line = txt.getLineAtOffset(txt.getCaretOffset());
 					//int col = txt.getCaretOffset() - txt.getOffsetAtLine(line) + 1;
-					if(mainfolder.getSelection().getControl() instanceof EditorComposite)
-						addToNavHistory(((EditorComposite)mainfolder.getSelection().getControl()).getFile(),line);
+					if(activeFolder().getSelection().getControl() instanceof EditorComposite)
+						addToNavHistory(((EditorComposite)activeFolder().getSelection().getControl()).getFile(),line);
 					// I do not deal with Reports for nav history (I ran into problems because their file instance is usually null)
-//					else if(mainfolder.getSelection().getControl() instanceof ReportComposite)
-//						addToNavHistory(((ReportComposite)mainfolder.getSelection().getControl()).getFile(),line);
+//					else if(activeFolder().getSelection().getControl() instanceof ReportComposite)
+//						addToNavHistory(((ReportComposite)activeFolder().getSelection().getControl()).getFile(),line);
 				}
 			  if(tabHistory.size() > TAB_HISTORY_LIMIT)
 				  tabHistory.remove(0); // Keep the history at TAB_HISTORY_LIMIT steps max
@@ -3244,6 +2912,8 @@ public class MainShell {
 		fileItem.setText("&File");
 		MenuItem editItem = new MenuItem(bar, SWT.CASCADE);
 		editItem.setText("&Edit");
+		MenuItem viewItem = new MenuItem(bar, SWT.CASCADE);
+		viewItem.setText("&View");
 		MenuItem toolsItem = new MenuItem(bar, SWT.CASCADE);
 		toolsItem.setText("&Tools");
 		MenuItem helpItem = new MenuItem(bar, SWT.CASCADE);
@@ -3257,14 +2927,16 @@ public class MainShell {
 		helpItem.setMenu(helpMenu);
 		Menu editMenu = new Menu(shell, SWT.DROP_DOWN);
 		editItem.setMenu(editMenu);
+		Menu viewMenu = new Menu(shell, SWT.DROP_DOWN);
+		viewItem.setMenu(viewMenu);
 
 		final MenuItem fileSave = new MenuItem(fileMenu, SWT.PUSH);
 		fileSave.setText("&Save\tCTRL+S");
 		fileSave.setImage(RepDevMain.smallActionSaveImage);
 		fileSave.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite)
-					((EditorComposite) mainfolder.getSelection().getControl()).saveFile(true);
+				if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite)
+					((EditorComposite) activeFolder().getSelection().getControl()).saveFile(true);
 			}
 		});
 
@@ -3276,11 +2948,11 @@ public class MainShell {
 			public void widgetSelected(SelectionEvent arg0) {
 				// FileDialog dialog;
 
-				if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite && mainfolder.getSelection().getData("modified") != null
-						&& !(Boolean) mainfolder.getSelection().getData("modified")) {
+				if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite && activeFolder().getSelection().getData("modified") != null
+						&& !(Boolean) activeFolder().getSelection().getData("modified")) {
 
 					FileDialog dialog;
-					SymitarFile file = ((EditorComposite) mainfolder.getSelection().getControl()).getFile();
+					SymitarFile file = ((EditorComposite) activeFolder().getSelection().getControl()).getFile();
 
 					if (file.isLocal())
 						dialog = new FileDialog(shell, FileDialog.Mode.SAVE, file.getDir());
@@ -3298,23 +2970,23 @@ public class MainShell {
 						// Remove any already open tabs of the new file, so if
 						// we are overrwriting, it gets updated and this is
 						// clear to the user
-						for (CTabItem item : mainfolder.getItems())
+						for (CTabItem item : panes.allItems())
 							if (item.getData("file") != null && item.getData("file").equals(result.get(0)))
 								item.dispose();
 
 						openFile(result.get(0));
 					}
-				} else if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite
-						&& mainfolder.getSelection().getData("modified") != null && (Boolean) mainfolder.getSelection().getData("modified")) {
+				} else if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite
+						&& activeFolder().getSelection().getData("modified") != null && (Boolean) activeFolder().getSelection().getData("modified")) {
 
 					FileDialog dialog;
 
-					SymitarFile file = ((EditorComposite) mainfolder.getSelection().getControl()).getFile();
-					int fileSym = ((EditorComposite) mainfolder.getSelection().getControl()).getFile().getSym();
-					boolean local = ((EditorComposite) mainfolder.getSelection().getControl()).getFile().isLocal();
+					SymitarFile file = ((EditorComposite) activeFolder().getSelection().getControl()).getFile();
+					int fileSym = ((EditorComposite) activeFolder().getSelection().getControl()).getFile().getSym();
+					boolean local = ((EditorComposite) activeFolder().getSelection().getControl()).getFile().isLocal();
 					dialog = new FileDialog(shell, FileDialog.Mode.SAVE, file.getDir());
 
-					String tmp = ((EditorComposite) mainfolder.getSelection().getControl()).getStyledText().getText();
+					String tmp = ((EditorComposite) activeFolder().getSelection().getControl()).getStyledText().getText();
 					/*
 					 * SymitarFile tmp1 = new
 					 * SymitarFile(System.getProperty("user.home"),"tmp_1_2_3");
@@ -3330,7 +3002,7 @@ public class MainShell {
 						SymitarFile tbs = new SymitarFile(path, result.get(0).getName(), result.get(0).getType());
 						System.out.println(path + "," + result.get(0).getName());
 						tbs.saveFile(tmp);
-						for (CTabItem item : mainfolder.getItems())
+						for (CTabItem item : panes.allItems())
 							if (item.getData("file") != null && item.getData("file").equals(result.get(0)))
 								item.dispose();
 						openFile(tbs);
@@ -3343,7 +3015,7 @@ public class MainShell {
 							tmp1.open();
 						} else {
 							tbs.saveFile(tmp);
-							for (CTabItem item : mainfolder.getItems())
+							for (CTabItem item : panes.allItems())
 								if (item.getData("file") != null && item.getData("file").equals(result.get(0)))
 									item.dispose();
 							openFile(tbs);
@@ -3377,9 +3049,9 @@ public class MainShell {
 			}
 
 			public void menuShown(MenuEvent e) {
-				filePrint.setEnabled(mainfolder.getSelection() != null);
-				fileSave.setEnabled(mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite);
-				fileSaveAs.setEnabled(mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite);
+				filePrint.setEnabled(activeFolder().getSelection() != null);
+				fileSave.setEnabled(activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite);
+				fileSaveAs.setEnabled(activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite);
 
 				int i;
 
@@ -3443,11 +3115,11 @@ public class MainShell {
 		editUndo.setText("Undo Typing\tCTRL+Z");
 		editUndo.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextEditorView)
-					((TabTextEditorView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).undo();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextEditorView)
+					((TabTextEditorView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).undo();
 			}
 		});
 
@@ -3456,11 +3128,11 @@ public class MainShell {
 		editRedo.setText("Redo Typing\tCTRL+Y");
 		editRedo.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextEditorView)
-					((TabTextEditorView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).redo();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextEditorView)
+					((TabTextEditorView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).redo();
 			}
 		});
 
@@ -3471,11 +3143,11 @@ public class MainShell {
 		editCut.setText("Cut\tCTRL+X");
 		editCut.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextView)
-					((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText().cut();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextView)
+					((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText().cut();
 			}
 		});
 
@@ -3484,11 +3156,11 @@ public class MainShell {
 		editCopy.setText("Copy\tCTRL+C");
 		editCopy.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextView)
-					((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText().copy();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextView)
+					((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText().copy();
 			}
 		});
 
@@ -3497,11 +3169,11 @@ public class MainShell {
 		editPaste.setText("Paste\tCTRL+V");
 		editPaste.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextView)
-					((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText().paste();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextView)
+					((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText().paste();
 			}
 		});
 
@@ -3512,11 +3184,11 @@ public class MainShell {
 		editSelectAll.setText("Select All\tCTRL+A");
 		editSelectAll.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent arg0) {
-				if (mainfolder.getSelectionIndex() == -1)
+				if (activeFolder().getSelectionIndex() == -1)
 					return;
 
-				if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextView)
-					((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText().selectAll();
+				if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextView)
+					((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText().selectAll();
 			}
 		});
 
@@ -3544,7 +3216,7 @@ public class MainShell {
 		editGotoLine.setText("Goto Line\tCTRL+L");
 		editGotoLine.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				StyledText txt = ((TabTextView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).getStyledText();
+				StyledText txt = ((TabTextView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).getStyledText();
 				GotoLineShell.show(txt.getParent().getShell(), txt);
 			}
 		});
@@ -3554,8 +3226,8 @@ public class MainShell {
 		editFormat.setImage(RepDevMain.smallFormatCodeImage);
 		editFormat.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if( mainfolder.getSelection() != null &&  mainfolder.getSelection().getControl() instanceof EditorComposite) {
-					((EditorComposite)mainfolder.getSelection().getControl()).sendToFormatter();
+				if( activeFolder().getSelection() != null &&  activeFolder().getSelection().getControl() instanceof EditorComposite) {
+					((EditorComposite)activeFolder().getSelection().getControl()).sendToFormatter();
 				}
 			}		    
 		});
@@ -3566,7 +3238,7 @@ public class MainShell {
 		replaceTabs.setImage(RepDevMain.smallFindReplaceImage);
 		replaceTabs.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if( mainfolder.getSelection() != null &&  mainfolder.getSelection().getControl() instanceof EditorComposite) {
+				if( activeFolder().getSelection() != null &&  activeFolder().getSelection().getControl() instanceof EditorComposite) {
 					ReplaceTabs();
 				}
 			}		    
@@ -3578,7 +3250,7 @@ public class MainShell {
 			}
 
 			public void menuShown(MenuEvent e) {
-				if (mainfolder.getSelectionIndex() == -1) {
+				if (activeFolder().getSelectionIndex() == -1) {
 					editRedo.setEnabled(false);
 					editUndo.setEnabled(false);
 
@@ -3602,30 +3274,67 @@ public class MainShell {
 					editFindNext.setEnabled(true);
 					editFind.setEnabled(true);
 
-					if( mainfolder.getSelection() != null &&  mainfolder.getSelection().getControl() instanceof EditorComposite){ 
+					if( activeFolder().getSelection() != null &&  activeFolder().getSelection().getControl() instanceof EditorComposite){
 						editFormat.setEnabled(true);
 						replaceTabs.setEnabled(true);
 					}
 
-					if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextEditorView
-							&& ((TabTextEditorView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).canRedo())
+					if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextEditorView
+							&& ((TabTextEditorView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).canRedo())
 						editRedo.setEnabled(true);
 					else
 						editRedo.setEnabled(false);
 
-					if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextEditorView
-							&& ((TabTextEditorView) mainfolder.getItem(mainfolder.getSelectionIndex()).getControl()).canUndo())
+					if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextEditorView
+							&& ((TabTextEditorView) activeFolder().getItem(activeFolder().getSelectionIndex()).getControl()).canUndo())
 						editUndo.setEnabled(true);
 					else
 						editUndo.setEnabled(false);
 
-					if (mainfolder.getItem(mainfolder.getSelectionIndex()).getControl() instanceof TabTextEditorView)
+					if (activeFolder().getItem(activeFolder().getSelectionIndex()).getControl() instanceof TabTextEditorView)
 						editGotoLine.setEnabled(true);
 					else
 						editGotoLine.setEnabled(false);
 				}
 			}
 
+		});
+
+		final MenuItem viewSplit = new MenuItem(viewMenu, SWT.NONE);
+		viewSplit.setText("&Move to Other View\tCTRL+\\");
+		viewSplit.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				splitEditorHere();
+			}
+		});
+
+		final MenuItem viewOrientation = new MenuItem(viewMenu, SWT.NONE);
+		viewOrientation.setText("Toggle Split &Orientation\tCTRL+SHIFT+\\");
+		viewOrientation.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				toggleSplitOrientation();
+			}
+		});
+
+		final MenuItem viewFocusOther = new MenuItem(viewMenu, SWT.NONE);
+		viewFocusOther.setText("&Focus Other View\tF6");
+		viewFocusOther.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				focusOtherEditorView();
+			}
+		});
+
+		viewMenu.addMenuListener(new MenuAdapter() {
+			@Override
+			public void menuShown(MenuEvent e) {
+				CTabItem sel = panes.active().getSelection();
+				viewSplit.setEnabled(sel != null && panes.canMove(sel));
+				viewOrientation.setEnabled(panes.isSplit());
+				viewFocusOther.setEnabled(panes.isSplit());
+			}
 		});
 
 		final MenuItem toolsOptions = new MenuItem(toolsMenu, SWT.PUSH);
@@ -3762,33 +3471,33 @@ public class MainShell {
 	}
 
 	protected void print() {
-		if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof TabTextView) {
+		if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof TabTextView) {
 			PrintDialog dialog = new PrintDialog(shell);
 			PrinterData data = dialog.open();
 
 			if (data != null) {
 				StyledTextPrintOptions options = new StyledTextPrintOptions();
 				options.footer = "\t\t<page>";
-				options.jobName = "RepDev - " + mainfolder.getSelection().getText();
+				options.jobName = "RepDev - " + activeFolder().getSelection().getText();
 				options.printLineBackground = false;
 				options.printTextFontStyle = true;
 				options.printTextForeground = true;
 				options.printTextBackground = true;
 
-				Runnable runnable = ((TabTextView) mainfolder.getSelection().getControl()).getStyledText().print(new Printer(data), options);
+				Runnable runnable = ((TabTextView) activeFolder().getSelection().getControl()).getStyledText().print(new Printer(data), options);
 				runnable.run();
 			}
 		}
 	}
 
 	public void showFindWindow() {
-		if (mainfolder.getSelection() == null)
+		if (activeFolder().getSelection() == null)
 			findReplaceShell.attach(null, false);
-		else if (mainfolder.getSelection().getControl() instanceof EditorComposite)
-			findReplaceShell.attach(((EditorComposite) mainfolder.getSelection().getControl()).getStyledText(), ((EditorComposite) mainfolder.getSelection().getControl())
+		else if (activeFolder().getSelection().getControl() instanceof EditorComposite)
+			findReplaceShell.attach(((EditorComposite) activeFolder().getSelection().getControl()).getStyledText(), ((EditorComposite) activeFolder().getSelection().getControl())
 					.getParser(), true);
-		else if (mainfolder.getSelection().getControl() instanceof ReportComposite)
-			findReplaceShell.attach(((ReportComposite) mainfolder.getSelection().getControl()).getStyledText(), null, false);
+		else if (activeFolder().getSelection().getControl() instanceof ReportComposite)
+			findReplaceShell.attach(((ReportComposite) activeFolder().getSelection().getControl()).getStyledText(), null, false);
 
 		findReplaceShell.open();
 	}
@@ -3821,8 +3530,8 @@ public class MainShell {
 	}
 
 	public void saveAllRepgens() {
-		if (mainfolder.getItems().length >= 1) {
-			for (CTabItem item : mainfolder.getItems()) {
+		if (panes.allItems().size() >= 1) {
+			for (CTabItem item : panes.allItems()) {
 				if ((item.getControl() instanceof EditorComposite) && item.getData("modified") != null && (Boolean) item.getData("modified")) {
 					System.out.println("Saving file: " + item.getData("file"));
 					((EditorComposite) item.getControl()).saveFile(true);
@@ -3833,19 +3542,19 @@ public class MainShell {
 	}
 
 	public void reopenCurrentTab() {
-		SymitarFile File = (SymitarFile) mainfolder.getSelection().getData("file");
+		SymitarFile File = (SymitarFile) activeFolder().getSelection().getData("file");
 		closeCurrentTab();
 		openFile(File);
 	}
 	
 	public void closeCurrentTab() {
-//		System.out.println(mainfolder.getSelection());
-//		if(mainfolder.getSelection() != null)
-//			mainfolder.getSelection().dispose();
-		if (mainfolder.getSelectionIndex() != -1) {
-			if (confirmClose(mainfolder.getSelection())) {
-				clearErrorAndTaskList(mainfolder.getSelection());
-				mainfolder.getSelection().dispose();
+//		System.out.println(activeFolder().getSelection());
+//		if(activeFolder().getSelection() != null)
+//			activeFolder().getSelection().dispose();
+		if (activeFolder().getSelectionIndex() != -1) {
+			if (confirmClose(activeFolder().getSelection())) {
+				clearErrorAndTaskList(activeFolder().getSelection());
+				activeFolder().getSelection().dispose();
 				setLineColumn();
 			}
 		}
@@ -3853,9 +3562,9 @@ public class MainShell {
 	
 	//Replace tabs in the document 
 	public void ReplaceTabs(){
-		StyledText txt = ((EditorComposite) mainfolder.getSelection().getControl()).getStyledText();
+		StyledText txt = ((EditorComposite) activeFolder().getSelection().getControl()).getStyledText();
 		//RepgenParser parser = ((EditorComposite)cur.getControl()).getParser();
-		RepgenParser parser = ((EditorComposite) mainfolder.getSelection().getControl()).getParser();
+		RepgenParser parser = ((EditorComposite) activeFolder().getSelection().getControl()).getParser();
 		txt.setRedraw(false);
 		if( parser != null)
 			parser.setReparse(false);
@@ -3952,17 +3661,17 @@ public class MainShell {
 		
 		savetb.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelection().getControl() instanceof EditorComposite)
-					((EditorComposite) mainfolder.getSelection().getControl()).saveFile(true);
+				if (activeFolder().getSelection().getControl() instanceof EditorComposite)
+					((EditorComposite) activeFolder().getSelection().getControl()).saveFile(true);
 			}
 		});
 
 		hltoggle.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if(mainfolder.getSelection().getControl() instanceof EditorComposite){
-					boolean highlight = ((EditorComposite) mainfolder.getSelection().getControl()).getHighlight();
+				if(activeFolder().getSelection().getControl() instanceof EditorComposite){
+					boolean highlight = ((EditorComposite) activeFolder().getSelection().getControl()).getHighlight();
 					highlight=(highlight)?false:true;
-					((EditorComposite) mainfolder.getSelection().getControl()).highlight(highlight,false);
+					((EditorComposite) activeFolder().getSelection().getControl()).highlight(highlight,false);
 					if(highlight){
 						hltoggle.setImage(RepDevMain.smallHighlight);
 					}else{
@@ -3974,8 +3683,8 @@ public class MainShell {
 
 		install.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelection().getControl() instanceof EditorComposite)
-					((EditorComposite) mainfolder.getSelection().getControl()).installRepgen(true);
+				if (activeFolder().getSelection().getControl() instanceof EditorComposite)
+					((EditorComposite) activeFolder().getSelection().getControl()).installRepgen(true);
 			}
 		});
 
@@ -3987,15 +3696,15 @@ public class MainShell {
 
 		run.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent e) {
-				if (mainfolder.getSelection().getControl() instanceof EditorComposite)
-					RepDevMain.mainShell.runReport(((EditorComposite) mainfolder.getSelection().getControl()).getFile());
+				if (activeFolder().getSelection().getControl() instanceof EditorComposite)
+					RepDevMain.mainShell.runReport(((EditorComposite) activeFolder().getSelection().getControl()).getFile());
 			}
 		});
 	}
 
 	private void setEditorBarStatus() {
-		if (mainfolder.getSelection().getControl() instanceof EditorComposite) {
-			SymitarFile file = ((EditorComposite) mainfolder.getSelection().getControl()).getFile();
+		if (activeFolder().getSelection().getControl() instanceof EditorComposite) {
+			SymitarFile file = ((EditorComposite) activeFolder().getSelection().getControl()).getFile();
 			if (file.getType() != FileType.REPGEN || file.isLocal())
 				install.setEnabled(false);
 			else
@@ -4023,19 +3732,15 @@ public class MainShell {
 		return shell;
 	}
 
-	public CTabFolder getMainfolder() {
-		return mainfolder;
-	}
-
 	/**
 	 * Tear down code folding on every open editor. Called when the user disables the
 	 * "Enable code folding" option so open tabs unfold and lose their fold gutter
 	 * immediately, rather than staying folded until reopened.
 	 */
 	public void disableFoldingOnOpenEditors() {
-		if (mainfolder == null || mainfolder.isDisposed())
+		if (activeFolder() == null || activeFolder().isDisposed())
 			return;
-		for (CTabItem tab : mainfolder.getItems()) {
+		for (CTabItem tab : panes.allItems()) {
 			if (tab.getControl() instanceof EditorComposite)
 				((EditorComposite) tab.getControl()).disableFolding();
 		}
@@ -4047,9 +3752,9 @@ public class MainShell {
 	 * without needing to reopen tabs.
 	 */
 	public void refreshEditorStyles() {
-		if (mainfolder == null || mainfolder.isDisposed())
+		if (activeFolder() == null || activeFolder().isDisposed())
 			return;
-		for (CTabItem tab : mainfolder.getItems()) {
+		for (CTabItem tab : panes.allItems()) {
 			if (tab.getControl() instanceof EditorComposite) {
 				FoldingManager fm = ((EditorComposite) tab.getControl()).getFolding();
 				if (fm != null)
@@ -4058,13 +3763,13 @@ public class MainShell {
 		}
 	}
 
-	private void setMainTitle(){
+	void setMainTitle(){
 		String server = "";
 		int sym;
 		
 		if(Config.getHostNameInTitle()) {
-			if (mainfolder.getSelection() != null && mainfolder.getSelection().getControl() instanceof EditorComposite && (mainfolder.getSelection() != null && ((EditorComposite) mainfolder.getSelection().getControl()).getFile() instanceof SymitarFile)) {
-				SymitarFile file =  ((EditorComposite) mainfolder.getSelection().getControl()).getFile();
+			if (activeFolder().getSelection() != null && activeFolder().getSelection().getControl() instanceof EditorComposite && (activeFolder().getSelection() != null && ((EditorComposite) activeFolder().getSelection().getControl()).getFile() instanceof SymitarFile)) {
+				SymitarFile file =  ((EditorComposite) activeFolder().getSelection().getControl()).getFile();
 				if(!file.isLocal()) {
 					sym =file.getSym();
 					server = " - " + RepDevMain.SESSION_INFO.get(sym).getServer();
@@ -4073,7 +3778,7 @@ public class MainShell {
 		}
 		
 		if (Config.getFileNameInTitle())
-			shell.setText(mainfolder.getSelection().getText() + " - " +RepDevMain.NAMESTR + server);
+			shell.setText(activeFolder().getSelection().getText() + " - " +RepDevMain.NAMESTR + server);
 		else
 			shell.setText(RepDevMain.NAMESTR + server);
 		

--- a/com/repdev/OptionsShell.java
+++ b/com/repdev/OptionsShell.java
@@ -52,9 +52,9 @@ public class OptionsShell {
 	// Controls
 	private Spinner tabSpinner;
 	private Combo styleCombo, hour, minute;
-	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
+	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, enableFoldingLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
 	private Text  serverText, portText, errCheckPrefix, errCheckSuffix, liveSYMText, liveSYMColorText, sourceControlDir;
-	private Button varsButton, neverTerm, useSSO, devForgetBox, backupEnable, fileNameInTitle, hostInTitle, viewLineNumbers, useSourceControl;
+	private Button varsButton, neverTerm, useSSO, devForgetBox, backupEnable, fileNameInTitle, hostInTitle, viewLineNumbers, enableFolding, useSourceControl;
 	private String ssoPass = "";
 
 	public static void show(Shell parent) {
@@ -104,6 +104,11 @@ public class OptionsShell {
 				Config.setFileNameInTitle(fileNameInTitle.getSelection());
 				Config.setHostNameInTitle(hostInTitle.getSelection());
 				Config.setViewLineNumbers(viewLineNumbers.getSelection());
+				Config.setFoldingEnabled(enableFolding.getSelection());
+				// Disabling takes effect on open editors immediately (unfold + remove the
+				// fold gutter); enabling applies the next time an editor is opened.
+				if (!enableFolding.getSelection() && RepDevMain.mainShell != null)
+					RepDevMain.mainShell.disableFoldingOnOpenEditors();
 				Config.setLiveSym(Integer.parseInt(liveSYMText.getText()));
 				Config.setLiveSymColor(liveSYMColorText.getText());
 				Config.setUseSourceControl(useSourceControl.getSelection());
@@ -125,6 +130,8 @@ public class OptionsShell {
 				if(styleCombo.getSelectionIndex() > -1) {
 				    Config.setStyle(styleCombo.getItem(styleCombo.getSelectionIndex()));
 				    SyntaxHighlighter.loadStyle(Config.getStyle());
+				    if (RepDevMain.mainShell != null)
+				        RepDevMain.mainShell.refreshEditorStyles();
 				}
 				
 				// Project file backup
@@ -487,6 +494,11 @@ public class OptionsShell {
 		viewLineNumbers = new Button(editorGroup, SWT.CHECK);
 		viewLineNumbers.setSelection((Config.getViewLineNumbers()));
 
+		enableFoldingLabel = new Label(editorGroup, SWT.NONE);
+		enableFoldingLabel.setText("Enable code folding");
+		enableFolding = new Button(editorGroup, SWT.CHECK);
+		enableFolding.setSelection((Config.getFoldingEnabled()));
+
 		Group noErrorCheckGroup = new Group(editorOptions,SWT.NONE);
 		noErrorCheckGroup.setText("No Error Check for these Files");
 		layout = new FormLayout();
@@ -518,6 +530,7 @@ public class OptionsShell {
 			fileNameInTitle.setSelection(true);
 			hostInTitle.setSelection(true);
 			viewLineNumbers.setSelection(true);
+			enableFolding.setSelection(true);
 			RepDevMain.saveSettings();
 		}
 		FormData data = new FormData();
@@ -647,6 +660,18 @@ public class OptionsShell {
 		data.top = new FormAttachment(hostInTitle);
 		data.right = new FormAttachment(100);
 		viewLineNumbers.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(0);
+		data.top = new FormAttachment(viewLineNumbersLabel);
+		data.width = 163;
+		enableFoldingLabel.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(enableFoldingLabel);
+		data.top = new FormAttachment(viewLineNumbers);
+		data.right = new FormAttachment(100);
+		enableFolding.setLayoutData(data);
 
 		data = new FormData();
 		data.left = new FormAttachment(0);

--- a/com/repdev/OptionsShell.java
+++ b/com/repdev/OptionsShell.java
@@ -51,8 +51,8 @@ public class OptionsShell {
 	
 	// Controls
 	private Spinner tabSpinner;
-	private Combo styleCombo, hour, minute;
-	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, enableFoldingLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
+	private Combo styleCombo, hour, minute, splitOrientation;
+	private Label varsLabel, serverLabel, portLabel, useSSOLabel, errChkPrefixLabel, errChkSuffixLabel, nameInTitleLabel, hostInTitleLabel, viewLineNumbersLabel, enableFoldingLabel, splitOrientationLabel, liveSYMLabel, liveSYMColorLabel, useSourceControlLabel, sourceControlDirLabel;
 	private Text  serverText, portText, errCheckPrefix, errCheckSuffix, liveSYMText, liveSYMColorText, sourceControlDir;
 	private Button varsButton, neverTerm, useSSO, devForgetBox, backupEnable, fileNameInTitle, hostInTitle, viewLineNumbers, enableFolding, useSourceControl;
 	private String ssoPass = "";
@@ -109,6 +109,9 @@ public class OptionsShell {
 				// fold gutter); enabling applies the next time an editor is opened.
 				if (!enableFolding.getSelection() && RepDevMain.mainShell != null)
 					RepDevMain.mainShell.disableFoldingOnOpenEditors();
+				Config.setSplitOrientation(splitOrientation.getSelectionIndex() == 1 ? SWT.VERTICAL : SWT.HORIZONTAL);
+				if (RepDevMain.mainShell != null)
+					RepDevMain.mainShell.getPanes().setOrientation(Config.getSplitOrientation());
 				Config.setLiveSym(Integer.parseInt(liveSYMText.getText()));
 				Config.setLiveSymColor(liveSYMColorText.getText());
 				Config.setUseSourceControl(useSourceControl.getSelection());
@@ -499,6 +502,12 @@ public class OptionsShell {
 		enableFolding = new Button(editorGroup, SWT.CHECK);
 		enableFolding.setSelection((Config.getFoldingEnabled()));
 
+		splitOrientationLabel = new Label(editorGroup, SWT.NONE);
+		splitOrientationLabel.setText("Split editor orientation");
+		splitOrientation = new Combo(editorGroup, SWT.DROP_DOWN | SWT.READ_ONLY);
+		splitOrientation.setItems(new String[] { "Side by side", "Stacked" });
+		splitOrientation.select(Config.getSplitOrientation() == SWT.VERTICAL ? 1 : 0);
+
 		Group noErrorCheckGroup = new Group(editorOptions,SWT.NONE);
 		noErrorCheckGroup.setText("No Error Check for these Files");
 		layout = new FormLayout();
@@ -531,6 +540,7 @@ public class OptionsShell {
 			hostInTitle.setSelection(true);
 			viewLineNumbers.setSelection(true);
 			enableFolding.setSelection(true);
+			splitOrientation.select(0);
 			RepDevMain.saveSettings();
 		}
 		FormData data = new FormData();
@@ -672,6 +682,18 @@ public class OptionsShell {
 		data.top = new FormAttachment(viewLineNumbers);
 		data.right = new FormAttachment(100);
 		enableFolding.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(0);
+		data.top = new FormAttachment(enableFolding);
+		data.width = 163;
+		splitOrientationLabel.setLayoutData(data);
+
+		data = new FormData();
+		data.left = new FormAttachment(splitOrientationLabel);
+		data.top = new FormAttachment(enableFolding);
+		data.right = new FormAttachment(100);
+		splitOrientation.setLayoutData(data);
 
 		data = new FormData();
 		data.left = new FormAttachment(0);

--- a/com/repdev/RepDevMain.java
+++ b/com/repdev/RepDevMain.java
@@ -39,6 +39,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 
 /**
  * Main run class, runs as first startup
@@ -353,6 +354,9 @@ public class RepDevMain {
 	private static void createGlobalHotkeys(){
 		Display.getDefault().addFilter(SWT.KeyDown, new Listener() {
 			public void handleEvent(Event e) {
+				Shell main = RepDevMain.mainShell == null ? null : RepDevMain.mainShell.getShell();
+				boolean mainActive = main != null && !main.isDisposed()
+						&& Display.getDefault().getActiveShell() == main;
 				if( e.stateMask == (SWT.CTRL | SWT.SHIFT) ){
 //					if(e.keyCode == SWT.F11)
 //						RepDevMain.mainShell.toggleFullScreen();
@@ -370,6 +374,11 @@ public class RepDevMain {
 					case 'O':
 						RepDevMain.mainShell.showOptions();
 						break;
+					case '\\':
+					case '|':
+						if (mainActive)
+							RepDevMain.mainShell.toggleSplitOrientation();
+						break;
 					}
 
 				}
@@ -379,8 +388,15 @@ public class RepDevMain {
 					case 'O':
 						RepDevMain.mainShell.showFileOpenMenu();
 						break;
+					case '\\':
+						if (mainActive)
+							RepDevMain.mainShell.splitEditorHere();
+						break;
 					}
 				}
+				else if (e.stateMask == 0 && e.keyCode == SWT.F6)
+					if (mainActive)
+						RepDevMain.mainShell.focusOtherEditorView();
 			}
 			});
 	}

--- a/com/repdev/ReportComposite.java
+++ b/com/repdev/ReportComposite.java
@@ -77,6 +77,13 @@ public class ReportComposite extends Composite implements TabTextView{
 		buildGUI();
 	}
 	
+	/**
+	 * Re-points this report view at a different tab item, for moves between editor panes.
+	 */
+	public void setTabItem(CTabItem tabItem) {
+		this.tabItem = tabItem;
+	}
+
 	public StyledText getStyledText(){
 		return txt;
 	}

--- a/styles/GhostRider.xml
+++ b/styles/GhostRider.xml
@@ -13,6 +13,10 @@
     <editor bgColor="#3F3F3F" fgColor="#F7E29F" line="#373737" token="#020000" font="Consolas" fontSize="11" />
     
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#B5A76A" shape="triangle" />
     
     <!-- Comments -->
     <comments fgColor="#7F9F7F" style="italic"/>

--- a/styles/blue.xml
+++ b/styles/blue.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$blue" fgColor="$blue" line="$blue" token="$blue" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$blue" />
     <variables fgColor="$blue" style="bold" />    
     <functions fgColor="$blue" style="bold" />    

--- a/styles/bright.xml
+++ b/styles/bright.xml
@@ -11,6 +11,10 @@
     <editor bgColor="FFFFFF" fgColor="000000" line="E8F2FE" token="C0C0C0" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#008000" />
     <variables fgColor="#000000" style="bold" />    
     <functions fgColor="#000080" style="bold" />    

--- a/styles/dark.xml
+++ b/styles/dark.xml
@@ -12,6 +12,10 @@
     
 	<comments fgColor="#7F7F7F" />
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#A0A0A0" shape="plusminus" />
     <variables fgColor="#00BF00" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    
     <keywords fgColor="#0000FF" />

--- a/styles/default.xml
+++ b/styles/default.xml
@@ -11,6 +11,10 @@
     <editor bgColor="FFFFFF" fgColor="000000" line="E8F2FE" token="C0C0C0" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#000000" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    

--- a/styles/green.xml
+++ b/styles/green.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$green" fgColor="$green" line="$green" token="$green" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$green" />
     <variables fgColor="$green" style="bold" />    
     <functions fgColor="$green" style="bold" />    

--- a/styles/midnight.xml
+++ b/styles/midnight.xml
@@ -11,6 +11,10 @@
     <editor bgColor="#220044" fgColor="#ffffff" line="#444499" token="#FFDD00" font="Courier New" fontSize="10" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#9E90C0" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#CCCC00" style="bold" />    
     <functions fgColor="#CCCC00" style="bold" />    

--- a/styles/monochrome.xml
+++ b/styles/monochrome.xml
@@ -11,6 +11,10 @@
     <editor bgColor="F1F1F1" fgColor="1D1D1D" line="D5D5D5" token="ABABAB" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#6A6A6A" shape="triangle" />
     <comments fgColor="#969AA1" />
     <variables fgColor="#515151" style="bold" />    
     <functions fgColor="#515151" style="bold" />    

--- a/styles/random.xml
+++ b/styles/random.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$rand" fgColor="$rand" line="$rand" token="$rand" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$rand" />
     <variables fgColor="$rand" style="bold" />    
     <functions fgColor="$rand" style="bold" />    

--- a/styles/red.xml
+++ b/styles/red.xml
@@ -11,6 +11,10 @@
     <editor bgColor="$red" fgColor="$red" line="$red" token="$red" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#808080" shape="triangle" />
     <comments fgColor="$red" />
     <variables fgColor="$red" style="bold" />    
     <functions fgColor="$red" style="bold" />    

--- a/styles/revised.xml
+++ b/styles/revised.xml
@@ -11,6 +11,10 @@
     <editor bgColor="F3F3F3" fgColor="300030" line="DEE6FF" token="A7A9BC" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A5A5A" shape="triangle" />
     <comments fgColor="#7F7F7F" />
     <variables fgColor="#300030" style="bold" />    
     <functions fgColor="#4848E0" style="bold" />    

--- a/styles/snow.xml
+++ b/styles/snow.xml
@@ -11,6 +11,10 @@
     <editor bgColor="D1D7DF" fgColor="374280" line="94B7E1" token="99A9C9" font="Courier New" fontSize="11" />
 
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#5A6178" shape="triangle" />
     <comments fgColor="#7F8896" />
     <variables fgColor="#005CFF" style="bold" />    
     <functions fgColor="#0000FF" style="bold" />    

--- a/styles/sunset.xml
+++ b/styles/sunset.xml
@@ -12,6 +12,10 @@
     
 	<comments fgColor="#7F0000" />
     <linenumber fgColor="#C0C0C0" />
+    <!-- Fold gutter markers. fgColor sets the icon color.
+         shape="triangle" (default) or shape="plusminus" for boxed +/- icons.
+         guideColor sets the vertical block-guide line; omit for a dimmed default. -->
+    <folding fgColor="#A86A4A" shape="triangle" />
     <variables fgColor="#DEA46B" style="bold" />    
     <functions fgColor="#E20000" style="bold" />    
     <keywords fgColor="#E20000" />


### PR DESCRIPTION
Implements issue #53  

- Right click a tab to open in other view.
- Once the other view exists, can drag any tabs between them.
- Added split editor orientation (Side by side, Stacked) in OptionsShell.
- Updated configuration handling for split orientation in the main application.
- Added keyboard shortcuts to toggle split orientation and split editor view.
- Added view menu with split controls
- Added a method in ReportComposite to re-point report views between editor panes.
- Extracted existing pane management to EditorPaneManager.java consolidate control and avoid future drift